### PR TITLE
[wip] image help 去锁优化

### DIFF
--- a/wiliwili/include/utils/image_helper.hpp
+++ b/wiliwili/include/utils/image_helper.hpp
@@ -14,31 +14,17 @@
  * 图片加载请求，每个请求对应一个ImageHelper的实例
  */
 class ImageHelper {
-    typedef std::list<std::shared_ptr<ImageHelper>> Pool;
+    typedef std::shared_ptr<ImageHelper> Ref;
+    typedef std::list<Ref> Pool;
 
 public:
-    ImageHelper(brls::Image* view);
-
+    ImageHelper();
     virtual ~ImageHelper();
-
-    /**
-     * 取消图片请求
-     */
-    void cancel();
-
-    void setImageView(brls::Image* view);
-
-    brls::Image* getImageView();
 
     /**
      * 设置要加载内容的图片组件。此函数需要工作在主线程。
      */
-    static std::shared_ptr<ImageHelper> with(brls::Image* view);
-
-    /**
-     * 加载网络图片。此函数需要工作在主线程。
-     */
-    void load(std::string url);
+    static void with(brls::Image* view, const std::string& url);
 
     /**
      * 取消请求，并清空图片。此函数需要工作在主线程。
@@ -78,23 +64,21 @@ public:
     inline static size_t REQUEST_THREADS = 1;
 
 protected:
-    virtual void requestImage();
+    void setImageView(brls::Image* view);
 
+    virtual void requestImage();
+    
     /**
      * 图片请求结束时调用
      */
-    void clean();
+    static void clean(brls::Image* view);
 
 private:
-    bool isCancel;
+    std::atomic_bool isCancel;
     brls::Image* imageView;
     std::string imageUrl;
-    Pool::iterator currentIter;
-
-    /// 清理图片或取消请求时，用来定位 ImageHelper
-    inline static std::unordered_map<brls::Image*, Pool::iterator> requestMap;
-
-    /// 请求队列，可复用其中的 ImageHelper
+    /// 请求队列对象池
     inline static Pool requestPool;
-    inline static std::mutex requestMutex;
+    /// 清理图片或取消请求时，用来定位 ImageHelper
+    inline static std::unordered_map<brls::Image*, Ref> requestMap;
 };

--- a/wiliwili/source/activity/gallery_activity.cpp
+++ b/wiliwili/source/activity/gallery_activity.cpp
@@ -26,7 +26,7 @@ public:
     explicit NetImageGalleryItem(const std::string& url){
         this->inflateFromXMLString(ImageGalleryItemXML);
         this->image->setImageFromRes("icon/bilibili_video.png");
-        ImageHelper::with(this->image)->load(url);
+        ImageHelper::with(this->image, url);
     }
     ~NetImageGalleryItem() override{
         ImageHelper::clear(this->image);

--- a/wiliwili/source/fragment/dynamic_tab.cpp
+++ b/wiliwili/source/fragment/dynamic_tab.cpp
@@ -23,7 +23,7 @@ public:
     void setUserInfo(const std::string& avatar, const std::string& username,
                      bool isUpdate = false) {
         this->labelUsername->setText(username);
-        ImageHelper::with(this->avatarView)->load(avatar);
+        ImageHelper::with(this->avatarView, avatar);
     }
 
     brls::Image* getAvatar() { return this->avatarView; }

--- a/wiliwili/source/fragment/mine_collection_video_list.cpp
+++ b/wiliwili/source/fragment/mine_collection_video_list.cpp
@@ -102,7 +102,7 @@ MineCollectionVideoList::MineCollectionVideoList(
     this->labelTitle->setText(data.title);
     this->labelSubtitle->setText(
         fmt::format("{}{}", data.media_count, "wiliwili/mine/num"_i18n));
-    ImageHelper::with(this->imageCover)->load(data.cover);
+    ImageHelper::with(this->imageCover, data.cover);
 
     this->requestCollectionList();
 }
@@ -149,8 +149,7 @@ void MineCollectionVideoList::requestCollectionList() {
                         "{}{} · {}: {}", result.info.media_count,
                         "wiliwili/mine/num"_i18n, "wiliwili/mine/creator"_i18n,
                         result.info.upper.name));
-                    ImageHelper::with(this->imageCover)
-                        ->load(result.info.cover);
+                    ImageHelper::with(this->imageCover, result.info.cover);
                 }
             });
         },

--- a/wiliwili/source/fragment/mine_tab.cpp
+++ b/wiliwili/source/fragment/mine_tab.cpp
@@ -144,7 +144,7 @@ void MineTab::onUserInfo(const bilibili::UserResult& data) {
     brls::sync([ASYNC_TOKEN, data]() {
         ASYNC_RELEASE
         labelUserName->setText(data.name);
-        ImageHelper::with(this->imageUserAvater)->load(data.face);
+        ImageHelper::with(this->imageUserAvater, data.face);
         if (data.sign.empty()) {
             labelSign->setText("这个人很神秘，什么都没有写");
         } else {

--- a/wiliwili/source/utils/image_helper.cpp
+++ b/wiliwili/source/utils/image_helper.cpp
@@ -8,6 +8,7 @@
 #include "utils/thread_helper.hpp"
 #include "borealis/core/thread.hpp"
 #include "stb_image.h"
+#include <fmt/format.h>
 
 #ifdef USE_WEBP
 #include <webp/decode.h>
@@ -26,101 +27,86 @@ public:
     ~ImageThreadPool() override { this->Stop(); }
 };
 
-ImageHelper::ImageHelper(brls::Image* view) : imageView(view) {}
+ImageHelper::ImageHelper() : imageView(nullptr) {
+    brls::Logger::verbose("new ImageHelper {}", fmt::ptr(this));
+}
 
 ImageHelper::~ImageHelper() {
-    brls::Logger::verbose("delete ImageHelper {}", (size_t)this);
-}
-
-std::shared_ptr<ImageHelper> ImageHelper::with(brls::Image* view) {
-    std::lock_guard<std::mutex> lock(requestMutex);
-    std::shared_ptr<ImageHelper> item;
-
-    if (!requestPool.empty() &&
-        (*requestPool.begin())->getImageView() == nullptr) {
-        // 复用请求，挪到队尾
-        item = *requestPool.begin();
-        item->setImageView(view);
-        requestPool.splice(requestPool.end(), requestPool, requestPool.begin());
-    } else {
-        // 新建 ImageHelper 实例
-        item = std::make_shared<ImageHelper>(view);
-        requestPool.emplace_back(item);
+    if (this->imageView) {
+        this->imageView->ptrUnlock();
+        requestMap.erase(imageView);
     }
 
-    auto iter         = --requestPool.end();
-    requestMap[view]  = iter;
-    item->currentIter = iter;
-    // 重置 "取消" 标记位
-    item->isCancel = false;
-    // 禁止图片组件销毁
-    item->imageView->ptrLock();
-    // 设置图片组件不处理纹理的销毁，由缓存统一管理纹理销毁
-    item->imageView->setFreeTexture(false);
-
-    brls::Logger::verbose("with view: {} {} {}", (size_t)view, (size_t)item.get(),
-                        (size_t)(*iter).get());
-
-    return item;
+    brls::Logger::verbose("delete ImageHelper {}", fmt::ptr(this));
 }
 
-void ImageHelper::load(std::string url) {
-    this->imageUrl = url;
-
-    brls::Logger::verbose("load view: {} {}", (size_t)this->imageView,
-                        (size_t)this);
-
-    //    std::unique_lock<std::mutex> lock(this->loadingMutex);
-
+void ImageHelper::with(brls::Image* view, const std::string& url) {
     // 检查是否存在缓存
-    int tex = brls::TextureCache::instance().getCache(this->imageUrl);
+    int tex = brls::TextureCache::instance().getCache(url);
     if (tex > 0) {
-        brls::Logger::verbose("cache hit: {}", this->imageUrl);
-        this->imageView->innerSetImage(tex);
-        this->clean();
+        brls::Logger::verbose("cache hit: {}", url);
+        view->innerSetImage(tex);
         return;
     }
 
-    //todo: 可能会发生同时请求多个重复链接的情况，此种情况下最好合并为一个请求
+    Ref item;
+    if (requestPool.empty()) {
+        item = std::make_shared<ImageHelper>();
+    } else {
+        item = requestPool.front();
+        requestPool.pop_front();
+    }
 
-    // 缓存网络图片
-    brls::Logger::verbose("request Image 1: {} {}", this->imageUrl,
-                          this->isCancel);
-    ImageThreadPool::instance().Submit([this]() {
-        brls::Logger::verbose("Submit view: {} {} {} {}", (size_t)this->imageView,
-                            (size_t)this, this->imageUrl, this->isCancel);
-        if (this->isCancel) {
-            this->clean();
-            return;
-        }
-        this->requestImage();
-    });
+    auto it = requestMap.insert(std::make_pair(view, item));
+    if (!it.second) {
+        //ToDo 上一个 brls::Image* 请求仍未结束
+        brls::Logger::warning("with view: {} {}", fmt::ptr(view),
+                              fmt::ptr(item));
+        return;
+    }
+
+    item->imageUrl = url;
+    item->isCancel.store(false);
+    item->setImageView(view);
+
+    //todo: 可能会发生同时请求多个重复链接的情况，此种情况下最好合并为一个请求
+    brls::Logger::verbose("request Image 1: {} {} {}", url, fmt::ptr(view),
+                          fmt::ptr(item));
+    ImageThreadPool::instance().Submit(
+        std::bind(&ImageHelper::requestImage, item));
 }
 
 void ImageHelper::requestImage() {
+    if (this->isCancel.load()) {
+        brls::sync(std::bind(&ImageHelper::clean, this->imageView));
+        return;
+    }
     brls::Logger::verbose("request Image 2: {} {}", this->imageUrl,
-                          this->isCancel);
+                          this->isCancel.load());
 
     // 请求图片
     cpr::Response r = cpr::Get(
 #ifndef VERIFY_SSL
         cpr::VerifySsl{false},
 #endif
-        cpr::Url{this->imageUrl},
-        cpr::ProgressCallback([this](...) -> bool { return !this->isCancel; }));
+        cpr::Url{this->imageUrl}, cpr::ProgressCallback([this](...) -> bool {
+            return !this->isCancel.load();
+        }));
 
     // 图片请求失败或取消请求
     if (r.status_code != 200 || r.downloaded_bytes == 0 || this->isCancel) {
         brls::Logger::verbose("request undone: {} {} {} {}", r.status_code,
-                              r.downloaded_bytes, this->isCancel, r.url.str());
+                              r.downloaded_bytes, this->isCancel.load(),
+                              r.url.str());
 
-        this->clean();
+        brls::sync(std::bind(&ImageHelper::clean, this->imageView));
         return;
     }
 
     brls::Logger::verbose("load pic:{} size:{} bytes by{} to {} {}",
-                          r.url.str(), r.downloaded_bytes, (size_t)this,
-                          (size_t)this->imageView, this->imageView->describe());
+                          r.url.str(), r.downloaded_bytes, fmt::ptr(this),
+                          fmt::ptr(this->imageView),
+                          this->imageView->describe());
 
     uint8_t* imageData = nullptr;
     int imageW = 0, imageH = 0;
@@ -144,24 +130,16 @@ void ImageHelper::requestImage() {
     brls::sync([this, r, imageData, imageW, imageH]() {
         // 再检查一遍缓存
         int tex = brls::TextureCache::instance().getCache(this->imageUrl);
+        if (tex == 0 && imageData) {
+            NVGcontext* vg = brls::Application::getNVGContext();
+            tex = nvgCreateImageRGBA(vg, imageW, imageH, 0, imageData);
+        }
         if (tex > 0) {
-            brls::Logger::verbose("cache hit 2: {}", this->imageUrl);
+            brls::TextureCache::instance().addCache(this->imageUrl, tex);
+            brls::Logger::verbose("load image: {}", this->imageUrl);
             this->imageView->innerSetImage(tex);
         } else {
-            NVGcontext* vg = brls::Application::getNVGContext();
-            if (imageData) {
-                tex = nvgCreateImageRGBA(vg, imageW, imageH, 0, imageData);
-            } else {
-                brls::Logger::error("Failed to load image: {}", this->imageUrl);
-            }
-
-            if (tex > 0) {
-                brls::TextureCache::instance().addCache(this->imageUrl, tex);
-                if (!this->isCancel) {
-                    brls::Logger::verbose("load image: {}", this->imageUrl);
-                    this->imageView->innerSetImage(tex);
-                }
-            }
+            brls::Logger::error("Failed to load image: {}", this->imageUrl);
         }
         if (imageData) {
 #ifdef USE_WEBP
@@ -170,43 +148,41 @@ void ImageHelper::requestImage() {
             stbi_image_free(imageData);
 #endif
         }
-        this->clean();
+        clean(this->imageView);
     });
 }
 
-void ImageHelper::clean() {
-    std::lock_guard<std::mutex> lock(requestMutex);
-
-    // 允许图片组件销毁
-    if (this->imageView) this->imageView->ptrUnlock();
-    // 移除请求，复用 ImageHelper (挪到队首)
-    requestPool.splice(requestPool.begin(), requestPool, this->currentIter);
-    this->imageView   = nullptr;
-    this->currentIter = requestPool.end();
+void ImageHelper::clean(brls::Image* view) {
+    auto it = requestMap.find(view);
+    if (it != requestMap.end()) {
+        it->second->imageView->ptrUnlock();
+        it->second->imageView = nullptr;
+        /// 归还对象
+        requestPool.push_back(it->second);
+        requestMap.erase(it);
+    }
 }
 
 void ImageHelper::clear(brls::Image* view) {
     brls::TextureCache::instance().removeCache(view->getTexture());
     view->clear();
-
-    std::lock_guard<std::mutex> lock(requestMutex);
-
     // 请求不存在
-    if (requestMap.find(view) == requestMap.end()) return;
-
-    brls::Logger::verbose("clear view: {} {}", (size_t)view,
-                        (size_t)(*requestMap[view]).get());
-
+    auto it = requestMap.find(view);
+    if (it == requestMap.end()) return;
+    brls::Logger::verbose("clear view: {} {}", fmt::ptr(view),
+                          fmt::ptr(it->second));
     // 请求没结束，取消请求
-    if ((*requestMap[view])->imageView == view) {
-        (*requestMap[view])->cancel();
-    }
-    requestMap.erase(view);
+    it->second->isCancel.store(true);
+    requestMap.erase(it);
 }
 
-void ImageHelper::cancel() {
-    brls::Logger::verbose("Cancel request: {}", this->imageUrl);
-    this->isCancel = true;
+void ImageHelper::setImageView(brls::Image* view) {
+    // 禁止图片组件销毁
+    view->ptrLock();
+    // 设置图片组件不处理纹理的销毁，由缓存统一管理纹理销毁
+    view->setFreeTexture(false);
+
+    this->imageView = view;
 }
 
 void ImageHelper::setRequestThreads(size_t num) {
@@ -214,7 +190,3 @@ void ImageHelper::setRequestThreads(size_t num) {
     ImageThreadPool::instance().min_thread_num = 1;
     ImageThreadPool::instance().max_thread_num = num;
 }
-
-void ImageHelper::setImageView(brls::Image* view) { this->imageView = view; }
-
-brls::Image* ImageHelper::getImageView() { return this->imageView; }

--- a/wiliwili/source/view/hots_card.cpp
+++ b/wiliwili/source/view/hots_card.cpp
@@ -20,7 +20,7 @@ void RecyclingGridItemHotsCard::setCard(const std::string& prefix,
         this->icon->setVisibility(brls::Visibility::GONE);
     } else {
         this->icon->setVisibility(brls::Visibility::VISIBLE);
-        ImageHelper::with(this->icon)->load(image);
+        ImageHelper::with(this->icon, image);
     }
 }
 

--- a/wiliwili/source/view/text_box.cpp
+++ b/wiliwili/source/view/text_box.cpp
@@ -368,7 +368,7 @@ RichTextImage::RichTextImage(std::string url, float width, float height,
     image->setCornerRadius(4);
     image->setScalingType(brls::ImageScalingType::FIT);
 
-    if (autoLoad) ImageHelper::with(image)->load(this->url);
+    if (autoLoad) ImageHelper::with(image, this->url);
 }
 
 RichTextImage::~RichTextImage() {

--- a/wiliwili/source/view/user_info.cpp
+++ b/wiliwili/source/view/user_info.cpp
@@ -36,7 +36,7 @@ void UserInfoView::setUserInfo(const std::string& avatar, const std::string& use
     } else {
         this->avatarView->getParent()->setVisibility(
             brls::Visibility::VISIBLE);
-        ImageHelper::with(this->avatarView)->load(avatar);
+        ImageHelper::with(this->avatarView, avatar);
     }
 }
 

--- a/wiliwili/source/view/video_card.cpp
+++ b/wiliwili/source/view/video_card.cpp
@@ -61,7 +61,7 @@ void RecyclingGridItemVideoCard::setCard(std::string pic, std::string title,
 
     this->labelTitle->setIsWrapping(true);
     this->labelTitle->setText(title);
-    ImageHelper::with(this->picture)->load(pic);
+    ImageHelper::with(this->picture, pic);
     this->labelCount->setText(wiliwili::num2w(view_count));
     this->labelDanmaku->setText(wiliwili::num2w(danmaku));
 
@@ -93,7 +93,7 @@ void RecyclingGridItemVideoCard::setCard(std::string pic, std::string title,
 
     this->labelTitle->setIsWrapping(true);
     this->labelTitle->setText(title);
-    ImageHelper::with(this->picture)->load(pic);
+    ImageHelper::with(this->picture, pic);
     this->labelCount->setText(wiliwili::num2w(view_count));
     this->labelDanmaku->setText(wiliwili::num2w(danmaku));
     this->labelDuration->setText(rightBottomBadge);
@@ -124,7 +124,7 @@ void RecyclingGridItemRankVideoCard::setCard(std::string pic, std::string title,
 
     this->labelTitle->setIsWrapping(true);
     this->labelTitle->setText(title);
-    ImageHelper::with(this->picture)->load(pic);
+    ImageHelper::with(this->picture, pic);
     this->labelCount->setText(wiliwili::num2w(view_count));
     this->labelDanmaku->setText(wiliwili::num2w(danmaku));
 
@@ -179,7 +179,7 @@ void RecyclingGridItemLiveVideoCard::setCard(std::string pic, std::string title,
     this->labelUsername->setText(username);
     this->labelTitle->setIsWrapping(false);
     this->labelTitle->setText(title);
-    ImageHelper::with(this->picture)->load(pic);
+    ImageHelper::with(this->picture, pic);
     this->labelCount->setText(wiliwili::num2w(view_count));
     this->labelDuration->setText(area);
     if (following) {
@@ -225,15 +225,15 @@ void RecyclingGridItemPGCVideoCard::setCard(std::string pic, std::string title,
     this->labelUsername->setText(username);
     this->labelTitle->setIsWrapping(false);
     this->labelTitle->setText(title);
-    ImageHelper::with(this->picture)->load(pic);
+    ImageHelper::with(this->picture, pic);
     this->labelDuration->setText(badge_bottom_right);
 
     if (!badge_top.empty()) {
-        ImageHelper::with(this->badgeTop)->load(badge_top);
+        ImageHelper::with(this->badgeTop, badge_top);
     }
 
     if (!badge_bottom_left.empty()) {
-        ImageHelper::with(this->badgeBottomLeft)->load(badge_bottom_left);
+        ImageHelper::with(this->badgeBottomLeft, badge_bottom_left);
     }
 }
 
@@ -289,7 +289,7 @@ void RecyclingGridItemSearchPGCVideoCard::setCard(
         this->boxTop->setVisibility(brls::Visibility::GONE);
     }
 
-    ImageHelper::with(this->picture)->load(pic);
+    ImageHelper::with(this->picture, pic);
 }
 
 RecyclingGridItem* RecyclingGridItemSearchPGCVideoCard::create() {
@@ -340,7 +340,7 @@ void RecyclingGridItemHistoryVideoCard::setCard(
     this->labelUsername->setText(username);
     this->labelTitle->setIsWrapping(true);
     this->labelTitle->setText(title);
-    ImageHelper::with(this->picture)->load(pic);
+    ImageHelper::with(this->picture, pic);
     this->labelCount->setText(leftBottomBadge);
     this->labelDuration->setText(rightBottomBadge);
     this->labelRightTop->setText(rightTopBadge);
@@ -421,7 +421,7 @@ void RecyclingGridItemCollectionVideoCard::setCard(
     this->labelTitle->setIsWrapping(true);
     this->labelTitle->setText(title);
     if (!pic.empty()) {
-        ImageHelper::with(this->picture)->load(pic);
+        ImageHelper::with(this->picture, pic);
     }
     this->labelCount->setText(leftBottomBadge);
     this->labelDuration->setText(rightBottomBadge);
@@ -451,7 +451,7 @@ void RecyclingGridItemRelatedVideoCard::setCard(std::string pic,
     this->labelUsername->setText(username);
     this->labelTitle->setIsWrapping(true);
     this->labelTitle->setText(title);
-    ImageHelper::with(this->picture)->load(pic);
+    ImageHelper::with(this->picture, pic);
     this->labelCount->setText(playCount);
     this->labelDanmaku->setText(danmakuCount);
     this->labelDuration->setText(rightBottomBadge);
@@ -482,7 +482,7 @@ void RecyclingGridItemSeasonSeriesVideoCard::setCard(
     this->labelUsername->setText(username);
     this->labelTitle->setIsWrapping(true);
     this->labelTitle->setText(title);
-    ImageHelper::with(this->picture)->load(pic);
+    ImageHelper::with(this->picture, pic);
     this->labelCount->setText(playCount);
     this->labelLike->setText(likeCount);
     this->badgeTop->setText(badge);


### PR DESCRIPTION
观察了一下 `ImageHelper::with` `ImageHelper::clean` 的调用都在主线程，所以对于 `requestPool` `requestMap` 的操作都在主线程就不需要加锁了

> 实际上 cpr::threadpool 已经给工作队列加锁了

1. `requestPool` 比起请求队列更像是个对象池
2. `share_ptr<ImageHelper>` 直接 bind 到请求线程上，请求线程未结束的时候对象不会释放，问题在于切换到 `brls::sync` 时候 ImageHelper 可能已经被释放掉了
3. `requestMap` 的 key 可以用来防止重复删除对象，可以解决2 的问题
