### PR TITLE
fix and extend live danmaku function

### DIFF
--- a/wiliwili/include/api/live/danmaku_live.hpp
+++ b/wiliwili/include/api/live/danmaku_live.hpp
@@ -32,7 +32,7 @@ public:
     std::function<void(std::string&&)> onMessage;
 
     void set_wait_time(int time);
-    int wait_time = 80;
+    int wait_time = 800;
 
     LiveDanmaku();
     ~LiveDanmaku();

--- a/wiliwili/include/api/live/danmaku_live.hpp
+++ b/wiliwili/include/api/live/danmaku_live.hpp
@@ -32,7 +32,7 @@ public:
     std::function<void(std::string&&)> onMessage;
 
     void set_wait_time(int time);
-    int wait_time = 600;
+    int wait_time = 80;
 
     LiveDanmaku();
     ~LiveDanmaku();

--- a/wiliwili/include/api/live/danmaku_live.hpp
+++ b/wiliwili/include/api/live/danmaku_live.hpp
@@ -43,7 +43,7 @@ public:
     std::atomic_bool ms_ev_ok{false};
 
     std::thread mongoose_thread;
-    std::thread heartbeat_thread;
+    std::thread task_thread;
     std::mutex mongoose_mutex;
     mg_mgr *mgr;
     mg_connection *nc;

--- a/wiliwili/include/api/live/extract_messages.hpp
+++ b/wiliwili/include/api/live/extract_messages.hpp
@@ -14,7 +14,8 @@ typedef enum {
     online_v2,//待确定，似乎是当前在线高能用户
     danmaku,//弹幕
     super_chat,//sc，醒目留言
-    initeract_word,//用户的进场消息，似乎现在vip也走这个
+    initeract_word,//普通用户的进场消息
+    entry_effect,//舰长进场消息
     send_gift,//发送的礼物
     combo_send,//连击礼物
     like_info_update,//人气值(助力值)

--- a/wiliwili/include/api/live/extract_messages.hpp
+++ b/wiliwili/include/api/live/extract_messages.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <stdint.h>
 #include <string>
 #include <vector>
 #include <cstdint>
@@ -72,6 +73,8 @@ typedef struct{
     int fan_medal_end_color;
     //牌子对应主播uid
     int fan_medal_liveuser_uid;
+    //是否为表情
+    uint8_t is_emoticon;
     //弹幕类型
     uint8_t dan_type;
     //弹幕尺寸

--- a/wiliwili/include/api/live/extract_messages.hpp
+++ b/wiliwili/include/api/live/extract_messages.hpp
@@ -1,5 +1,138 @@
+//
+// Created by maye174 on 2023/4/6.
+//
+
+#pragma once
 
 #include <string>
 #include <vector>
 
-std::vector<std::string> extract_danmu_messages(const std::vector<std::string>& messages);
+
+typedef enum {
+    watched_change,//在线人数更新，xx人看过
+    online_cnt,//当前在线人数
+    online_v2,//待确定，似乎是当前在线高能用户
+    danmaku,//弹幕
+    super_chat,//sc，醒目留言
+    initeract_word,//用户的进场消息，似乎现在vip也走这个
+    send_gift,//发送的礼物
+    combo_send,//连击礼物
+    like_info_update,//人气值(助力值)
+    like_info_click,//给主播点赞
+}message_t; //还有上舰长，续费信息什么的，暂时不加
+
+
+typedef struct{
+    //b站会直接传3个值{"num":23592,"text_large":"2.3万人看过","text_small":"2.3万"}
+    //真的浪费
+    int num;
+}watched_change_t;
+
+typedef struct{
+    //代表在线人数
+    int count;
+}online_cnt_t;
+
+typedef struct{
+    //头像
+    void *face_photo[10];
+    //名字
+    std::string user_name[10];
+    //暂时先写这俩
+}online_v2_t;
+
+//弹幕类型，内容太多，暂时写这么多
+//
+//很多重复内容，感觉不是同一批人写的，或者可能b站想换协议，
+typedef struct{
+    //用户名字
+    std::string user_name;
+    //用户名字颜色，一般为舰长以上有，即vip等级1以上
+    std::string user_name_color;
+    //弹幕内容
+    std::string dan;
+    //粉丝牌子名字
+    std::string fan_medal_name;
+    //粉丝牌子对应主播名字
+    std::string fan_medal_liveuser_name;
+    //用户uid
+    int user_uid;
+    //弹幕颜色
+    int dan_color;
+    //牌子对应直播间号
+    int fan_medal_roomid;
+    //牌子字体颜色 目前应该都是白色
+    int fan_medal_font_color;
+    //牌子边框颜色
+    int fan_medal_border_color;
+    //牌子开始颜色
+    int fan_medal_start_color;
+    //牌子结束颜色
+    int fan_medal_end_color;
+    //牌子对应主播uid
+    int fan_medal_liveuser_uid;
+    //弹幕类型
+    uint8_t dan_type;
+    //弹幕尺寸
+    uint8_t dan_size;
+    //用户直播等级 0~60
+    //待确定，有的用户发的消息为0级
+    uint8_t user_level;
+    //用户在本房VIP等级，0~3，不是vip为0
+    uint8_t user_vip_level;
+    //牌子等级
+    uint8_t fan_medal_level;
+    //牌子对应直播间VIP等级，0~3，不是vip为0
+    uint8_t fan_medal_vip_level;
+    //是否为房管
+    uint8_t is_guard;
+    //荣耀值，就是用户名和牌子前面那个带蓝色框子的数字 暂时不用
+    uint8_t glory_v;
+}danmaku_t; //Maye174: 为了对齐内存，乱序排
+
+typedef struct{
+    //todo
+}super_chat_t;
+
+
+//这里b站的接口命名更混乱，感觉b站后面会逐步换掉
+typedef struct{
+    //用户名字
+    std::string user_name;
+    //牌子字体颜色 目前应该都是白色
+    int fan_medal_font_color;
+    //牌子边框颜色
+    int fan_medal_border_color;
+    //牌子开始颜色
+    int fan_medal_start_color;
+    //牌子结束颜色
+    int fan_medal_end_color;
+    //牌子所在主播uid
+    int fan_medal_uid;
+    //牌子等级
+    uint8_t fan_medal_level;
+}initeract_word_t; 
+
+typedef struct{
+    //todo
+}send_gift_t;
+
+typedef struct{
+    //todo
+}combo_send_t;
+
+typedef struct{
+    //人气值，但是这个值叫click_count，我有点搞不清
+    int count;
+}like_info_update_t;
+
+typedef struct{
+    //todo
+}like_info_click_t;
+
+typedef struct live_t{
+    message_t type;
+    void *ptr;
+}live_t;
+
+std::vector<live_t> extract_messages(const std::vector<std::string>& messages);

--- a/wiliwili/include/api/live/extract_messages.hpp
+++ b/wiliwili/include/api/live/extract_messages.hpp
@@ -6,7 +6,7 @@
 
 #include <string>
 #include <vector>
-
+#include <cstdint>
 
 typedef enum {
     watched_change,//在线人数更新，xx人看过
@@ -37,7 +37,7 @@ typedef struct{
     //头像
     void *face_photo[10];
     //名字
-    std::string user_name[10];
+    char * user_name[10];
     //暂时先写这俩
 }online_v2_t;
 
@@ -46,15 +46,15 @@ typedef struct{
 //很多重复内容，感觉不是同一批人写的，或者可能b站想换协议，
 typedef struct{
     //用户名字
-    std::string user_name;
+    char * user_name;
     //用户名字颜色，一般为舰长以上有，即vip等级1以上
-    std::string user_name_color;
+    char * user_name_color;
     //弹幕内容
-    std::string dan;
+    char * dan;
     //粉丝牌子名字
-    std::string fan_medal_name;
+    char * fan_medal_name;
     //粉丝牌子对应主播名字
-    std::string fan_medal_liveuser_name;
+    char * fan_medal_liveuser_name;
     //用户uid
     int user_uid;
     //弹幕颜色
@@ -90,6 +90,9 @@ typedef struct{
     uint8_t glory_v;
 }danmaku_t; //Maye174: 为了对齐内存，乱序排
 
+danmaku_t* danmaku_t_init();
+void danmaku_t_free(danmaku_t* p);
+
 typedef struct{
     //todo
 }super_chat_t;
@@ -98,7 +101,7 @@ typedef struct{
 //这里b站的接口命名更混乱，感觉b站后面会逐步换掉
 typedef struct{
     //用户名字
-    std::string user_name;
+    char * user_name;
     //牌子字体颜色 目前应该都是白色
     int fan_medal_font_color;
     //牌子边框颜色
@@ -112,6 +115,8 @@ typedef struct{
     //牌子等级
     uint8_t fan_medal_level;
 }initeract_word_t; 
+
+initeract_word_t *initeract_word_t_init();
 
 typedef struct{
     //todo
@@ -130,7 +135,7 @@ typedef struct{
     //todo
 }like_info_click_t;
 
-typedef struct live_t{
+typedef struct{
     message_t type;
     void *ptr;
 }live_t;

--- a/wiliwili/include/api/live/ws_utils.hpp
+++ b/wiliwili/include/api/live/ws_utils.hpp
@@ -1,4 +1,8 @@
+//
+// Created by maye174 on 2023/4/6.
+//
 
+#pragma once
 #include <vector>
 #include <string>
 #include <cstdint>

--- a/wiliwili/source/activity/live_player_activity.cpp
+++ b/wiliwili/source/activity/live_player_activity.cpp
@@ -24,7 +24,7 @@ static void process_danmaku(danmaku_t *dan){
     //...
 
     //弹幕加载到视频中去
-    double time = MPVCore::instance().getPlaybackTime() + 0.1;
+    double time = MPVCore::instance().getPlaybackTime() + 0.3;
     std::string combined_attr = tostr(time) + comma + tostr(dan->dan_type) + comma
                                 + tostr(dan->dan_size) + comma + tostr(dan->dan_color) + comma
                                 + tem + tostr(dan->user_level);

--- a/wiliwili/source/activity/live_player_activity.cpp
+++ b/wiliwili/source/activity/live_player_activity.cpp
@@ -16,10 +16,10 @@
 
 using namespace brls::literals;
 
-static char comma = ',';
-static std::string tem = "0,0,0,0,";//临时方案
 #define tostr(x) std::to_string(x)
 static void process_danmaku(danmaku_t *dan){
+    char comma = ',';
+    std::string tem = "0,0,0,0,";
     //做其他处理
     //...
 

--- a/wiliwili/source/activity/live_player_activity.cpp
+++ b/wiliwili/source/activity/live_player_activity.cpp
@@ -18,17 +18,19 @@ using namespace brls::literals;
 
 static char comma = ',';
 static std::string tem = "0,0,0,0,";//临时方案
-#define t_s(x) std::to_string(x)
+#define tostr(x) std::to_string(x)
 static void process_danmaku(danmaku_t *dan){
     //做其他处理
     //...
 
     //弹幕加载到视频中去
     double time = MPVCore::instance().getPlaybackTime() + 0.1;
-    std::string combined_attr = t_s(time) + comma + t_s(dan->dan_type) + comma
-                                + t_s(dan->dan_size) + comma + t_s(dan->dan_color) + comma
-                                + tem + t_s(dan->user_level);
-    DanmakuCore::instance().addSingleDanmaku(DanmakuItem(std::move(dan->dan), combined_attr));
+    std::string combined_attr = tostr(time) + comma + tostr(dan->dan_type) + comma
+                                + tostr(dan->dan_size) + comma + tostr(dan->dan_color) + comma
+                                + tem + tostr(dan->user_level);
+    DanmakuCore::instance().addSingleDanmaku(DanmakuItem(dan->dan, combined_attr));
+
+    danmaku_t_free(dan);
 }
 
 static void onDanmakuReceived(std::string&& message) {
@@ -42,10 +44,13 @@ static void onDanmakuReceived(std::string&& message) {
 
     for(auto &&live_msg : extract_messages(messages)){
         if(live_msg.type == danmaku){
+            if(!live_msg.ptr) continue;
             process_danmaku((danmaku_t *)live_msg.ptr);
             free(live_msg.ptr);
+        } else if (live_msg.type == watched_change) {
+            //todo
+            free(live_msg.ptr);
         }
-        
     }
 }
 

--- a/wiliwili/source/api/danmaku_live.cpp
+++ b/wiliwili/source/api/danmaku_live.cpp
@@ -108,7 +108,7 @@ void LiveDanmaku::connect(int room_id, int uid) {
                 break;
             }
             this->mongoose_mutex.unlock();
-            mg_mgr_poll(this->mgr, wait_time);
+            mg_mgr_poll(this->mgr, this->wait_time);
         }
         mg_mgr_free(this->mgr);
         delete this->mgr;

--- a/wiliwili/source/api/danmaku_live.cpp
+++ b/wiliwili/source/api/danmaku_live.cpp
@@ -10,6 +10,7 @@
 #include <iostream>
 #include <chrono>
 #include <queue>
+#include <condition_variable>
 
 #include "live/danmaku_live.hpp"
 #include "live/ws_utils.hpp"

--- a/wiliwili/source/api/danmaku_live.cpp
+++ b/wiliwili/source/api/danmaku_live.cpp
@@ -12,7 +12,6 @@
 
 #include "live/danmaku_live.hpp"
 #include "live/ws_utils.hpp"
-#include "live/extract_messages.hpp"
 
 #ifdef _WIN32
 #include <winsock2.h>
@@ -127,7 +126,7 @@ void LiveDanmaku::send_join_request(int room_id, int uid) {
     json join_request = {
         {"clientver", "1.6.3"},
         {"platform", "web"},
-        {"protover", 0},
+        {"protover", 2},
         {"roomid", room_id},
         {"uid", uid},
         {"type", 2}

--- a/wiliwili/source/api/util/extract_messages.cpp
+++ b/wiliwili/source/api/util/extract_messages.cpp
@@ -86,21 +86,20 @@ std::vector<live_t> extract_messages(const std::vector<std::string>& messages) {
                 continue;
             }
 
-            if (!info[0].is_array() || info[0].size() < 4) 
-                continue;
-            auto& attribute = info[0];
-            if(attribute[1].is_number())
-                dan->dan_type = attribute[1].get<int>();
+            if (info[0].is_array() && info[0].size() > 12) {
+                auto& attribute = info[0];
+                if(attribute[1].is_number())
+                    dan->dan_type = attribute[1].get<int>();
 
-            if(attribute[2].is_number())
-                dan->dan_size = attribute[2].get<int>();
+                if(attribute[2].is_number())
+                    dan->dan_size = attribute[2].get<int>();
 
-            if(attribute[3].is_number())
-                dan->dan_color = attribute[3].get<int>();
-                
-            if(attribute[12].is_number())
-                dan->is_emoticon = attribute[12].get<int>();
+                if(attribute[3].is_number())
+                    dan->dan_color = attribute[3].get<int>();
 
+                if(attribute[12].is_number())
+                    dan->is_emoticon = attribute[12].get<int>();
+            }
             
             if(info[1].is_string()){
                 dan->dan = to_cstr(info[1].get_ref<const std::string&>());

--- a/wiliwili/source/api/util/extract_messages.cpp
+++ b/wiliwili/source/api/util/extract_messages.cpp
@@ -20,6 +20,7 @@ danmaku_t* danmaku_t_init(){
     ret->fan_medal_start_color = 0;
     ret->fan_medal_end_color = 0;
     ret->fan_medal_liveuser_uid = 0;
+    ret->is_emoticon = 0;
     ret->dan_type = 1;
     ret->dan_size = 25;
     ret->user_level = 1;
@@ -96,6 +97,9 @@ std::vector<live_t> extract_messages(const std::vector<std::string>& messages) {
 
             if(attribute[3].is_number())
                 dan->dan_color = attribute[3].get<int>();
+                
+            if(attribute[12].is_number())
+                dan->is_emoticon = attribute[12].get<int>();
 
             
             if(info[1].is_string()){

--- a/wiliwili/source/api/util/extract_messages.cpp
+++ b/wiliwili/source/api/util/extract_messages.cpp
@@ -12,6 +12,22 @@ danmaku_t* danmaku_t_init(){
     ret->dan = nullptr;
     ret->fan_medal_name = nullptr;
     ret->fan_medal_liveuser_name = nullptr;
+    ret->user_uid = 0;
+    ret->dan_color = 16777215;
+    ret->fan_medal_roomid = 0;
+    ret->fan_medal_font_color = 0;
+    ret->fan_medal_border_color = 0;
+    ret->fan_medal_start_color = 0;
+    ret->fan_medal_end_color = 0;
+    ret->fan_medal_liveuser_uid = 0;
+    ret->dan_type = 1;
+    ret->dan_size = 25;
+    ret->user_level = 1;
+    ret->user_vip_level = 0;
+    ret->fan_medal_level = 0;
+    ret->fan_medal_vip_level = 0;
+    ret->is_guard = 0;
+    ret->glory_v = 0;
     return ret;
 }
 
@@ -85,60 +101,62 @@ std::vector<live_t> extract_messages(const std::vector<std::string>& messages) {
             if(info[1].is_string()){
                 dan->dan = to_cstr(info[1].get_ref<const std::string&>());
             }
-            if(!info[2].is_array() || info[2].size() != 8) 
-                continue;
-            auto& user = info[2];
-            if(user[0].is_number())
-                dan->user_uid = user[0].get<int>();
 
-            if(user[1].is_string()) 
-                dan->user_name = to_cstr(user[1].get_ref<const std::string&>());
+            if(info[2].is_array() && info[2].size() == 8) {
+                auto& user = info[2];
+                if(user[0].is_number())
+                    dan->user_uid = user[0].get<int>();
 
-            if(user[2].is_number())
-                dan->is_guard = user[2].get<int>();
+                if(user[1].is_string()) 
+                    dan->user_name = to_cstr(user[1].get_ref<const std::string&>());
 
-            if(user[7].is_string()) 
-                dan->user_name_color = to_cstr(user[7].get_ref<const std::string&>());
-            
-            if(info[3].is_array() && info[3].size() == 13)
-                continue;
-            
-            auto& fan = info[3];
-            if(fan[0].is_number())
-                dan->fan_medal_level = fan[0].get<int>();
+                if(user[2].is_number())
+                    dan->is_guard = user[2].get<int>();
 
-            if(fan[1].is_string()) 
-                dan->fan_medal_name = to_cstr(fan[1].get_ref<const std::string&>());
+                if(user[7].is_string()) 
+                    dan->user_name_color = to_cstr(user[7].get_ref<const std::string&>());
+            }
 
-            if(fan[2].is_string()) 
-                dan->fan_medal_liveuser_name = to_cstr(fan[2].get_ref<const std::string&>());
+            if(info[3].is_array() && info[3].size() == 13) {
 
-            if(fan[3].is_number())
-                dan->fan_medal_roomid = fan[3].get<int>();
+                auto& fan = info[3];
+                if(fan[0].is_number())
+                    dan->fan_medal_level = fan[0].get<int>();
 
-            if(fan[6].is_number())
-                dan->fan_medal_font_color = fan[6].get<int>();
+                if(fan[1].is_string()) 
+                    dan->fan_medal_name = to_cstr(fan[1].get_ref<const std::string&>());
 
-            if(fan[7].is_number())
-                dan->fan_medal_border_color = fan[7].get<int>();
+                if(fan[2].is_string()) 
+                    dan->fan_medal_liveuser_name = to_cstr(fan[2].get_ref<const std::string&>());
 
-            if(fan[8].is_number())
-                dan->fan_medal_end_color = fan[8].get<int>();
+                if(fan[3].is_number())
+                    dan->fan_medal_roomid = fan[3].get<int>();
 
-            if(fan[9].is_number())
-                dan->fan_medal_start_color = fan[9].get<int>();
+                if(fan[6].is_number())
+                    dan->fan_medal_font_color = fan[6].get<int>();
 
-            if(fan[10].is_number())
-                dan->fan_medal_vip_level = fan[10].get<int>();
+                if(fan[7].is_number())
+                    dan->fan_medal_border_color = fan[7].get<int>();
 
-            if(fan[12].is_number())
-                dan->fan_medal_liveuser_uid = fan[12].get<int>();
+                if(fan[8].is_number())
+                    dan->fan_medal_end_color = fan[8].get<int>();
 
-            
+                if(fan[9].is_number())
+                    dan->fan_medal_start_color = fan[9].get<int>();
+
+                if(fan[10].is_number())
+                    dan->fan_medal_vip_level = fan[10].get<int>();
+
+                if(fan[12].is_number())
+                    dan->fan_medal_liveuser_uid = fan[12].get<int>();
+
+            }
+
             if(info[4].is_array() && info[4].size() > 0){
                 if(info[4][0].is_number())
                     dan->user_level = info[4][0].get<int>();
             }
+            
             if(info[7].is_number()){
                 dan->user_vip_level = info[7].get<int>();
             }

--- a/wiliwili/source/api/util/extract_messages.cpp
+++ b/wiliwili/source/api/util/extract_messages.cpp
@@ -2,7 +2,7 @@
 #include "live/extract_messages.hpp"
 
 #include <nlohmann/json.hpp>
-#include <corecrt_malloc.h>
+#include <stdlib.h>
 
 
 danmaku_t* danmaku_t_init(){

--- a/wiliwili/source/api/util/extract_messages.cpp
+++ b/wiliwili/source/api/util/extract_messages.cpp
@@ -3,37 +3,110 @@
 
 #include <nlohmann/json.hpp>
 
+#include <malloc.h>
 #include <utility>
 
-std::vector<std::string> extract_danmu_messages(const std::vector<std::string>& messages) {
+std::vector<live_t> extract_messages(const std::vector<std::string>& messages) {
 
-    std::vector<std::string> danmu_messages;
-    danmu_messages.reserve(messages.size()); // 预留空间
+    std::vector<live_t> live_messages;
+    live_messages.reserve(messages.size()); // 预留空间
 
     for (auto& message : messages) {
 
-        // // 简单验证
-        // if (message.size() < 10 || 
-        //     message.substr(0, 5) != "{\"cmd\"") {
-        //     continue; 
-        // }
+        nlohmann::json json_message = nlohmann::json::parse(message); 
 
-        //try {
-            nlohmann::json json_message = nlohmann::json::parse(message); 
+        auto it = json_message.find("cmd");
+        if (it != json_message.end()) {
+            
+            if (it->get<std::string>() == "WATCHED_CHANGE") {
+                auto& num = json_message["data"]["num"];
 
-            auto it = json_message.find("cmd");
-            if (it != json_message.end() && it->get<std::string>() == "DANMU_MSG") {
-                
+                if(!num.is_number()) continue;
+
+                watched_change_t *wc = (watched_change_t *)malloc(sizeof(watched_change_t));
+
+                live_messages.emplace_back(live_t{.type = watched_change, .ptr = wc});
+
+            } else if (it->get<std::string>() == "DANMU_MSG") {
                 auto& info = json_message["info"];
-                if (info.is_array() && info.size() > 1) {
-                    // 直接插入结果,避免中间变量
-                    danmu_messages.emplace_back(info[1].get_ref<const std::string&>());
-                }
-            }
 
-        //} catch(const std::exception& e) {
-          // 忽略JSON解析错误
-        //}
+                if(!info.is_array()) continue;
+
+                danmaku_t *dan = (danmaku_t *)malloc(sizeof(danmaku_t));
+
+                if (info.size() > 0 and info[0].is_array() and info[0].size() > 3) {
+                    auto& attribute = info[0];
+                    if(attribute[1].is_number())
+                        dan->dan_type = attribute[1].get<int>();
+
+                    if(attribute[2].is_number())
+                        dan->dan_size = attribute[2].get<int>();
+
+                    if(attribute[3].is_number())
+                        dan->dan_color = attribute[3].get<int>();
+
+                }
+                if(info.size() > 1 and info[1].is_string()){
+                    dan->dan = info[1].get_ref<const std::string&>();
+                }
+                if(info.size() > 2 and info[2].is_array() and info[2].size() == 8) {
+                    auto& user = info[2];
+                    if(user[0].is_number())
+                        dan->user_uid = user[0].get<int>();
+
+                    if(user[1].is_string())
+                        dan->user_name = user[1].get_ref<std::string&>();
+
+                    if(user[2].is_number())
+                        dan->is_guard = user[2].get<int>();
+
+                    if(user[7].is_string()) 
+                        dan->user_name_color = user[7].get_ref<std::string&>();
+                }
+                if(info.size() > 3 and info[3].is_array() and info[3].size() == 13){
+                    auto& fan = info[3];
+                    if(fan[0].is_number())
+                        dan->fan_medal_level = fan[0].get<int>();
+
+                    if(fan[1].is_string()) 
+                        dan->fan_medal_name = fan[1].get_ref<std::string&>();
+
+                    if(fan[2].is_string()) 
+                        dan->fan_medal_liveuser_name = fan[2].get_ref<std::string&>();
+
+                    if(fan[3].is_number())
+                        dan->fan_medal_roomid = fan[3].get<int>();
+
+                    if(fan[6].is_number())
+                        dan->fan_medal_font_color = fan[6].get<int>();
+
+                    if(fan[7].is_number())
+                        dan->fan_medal_border_color = fan[7].get<int>();
+
+                    if(fan[8].is_number())
+                        dan->fan_medal_end_color = fan[8].get<int>();
+
+                    if(fan[9].is_number())
+                        dan->fan_medal_start_color = fan[9].get<int>();
+
+                    if(fan[10].is_number())
+                        dan->fan_medal_vip_level = fan[10].get<int>();
+
+                    if(fan[12].is_number())
+                        dan->fan_medal_liveuser_uid = fan[12].get<int>();
+
+                }
+                if(info.size() > 4 and info[4].is_array() and info[4].size() > 0){
+                    if(info[4][0].is_number())
+                        dan->user_level = info[4][0].get<int>();
+                }
+                if(info.size() > 7 and info[7].is_number()){
+                    dan->user_vip_level = info[7].get<int>();
+                }
+                live_messages.emplace_back(live_t{.type = danmaku, .ptr = dan});
+            }
+        }
+
     }
-    return danmu_messages;
+    return live_messages;
 }

--- a/wiliwili/source/api/util/ws_utils.cpp
+++ b/wiliwili/source/api/util/ws_utils.cpp
@@ -51,14 +51,14 @@ std::vector<std::string> parse_packet(const std::vector<uint8_t>& data) {
 
             if (protocol_version == 0) {
                 messages.emplace_back(std::move(body));
-                break;
+                //break;
             }
             else if (protocol_version == 2){
                 strm.avail_in = body.size();
                 strm.next_in = const_cast<Bytef*>(reinterpret_cast<const Bytef*>(body.data()));
                 if (inflateInit(&strm) != Z_OK) {
                     std::cerr << "Failed to initialize zlib" << std::endl;
-                    break;
+                    continue;
                 }
                 do {
                     std::vector<uint8_t> buffer(body.size() * 3);
@@ -66,7 +66,7 @@ std::vector<std::string> parse_packet(const std::vector<uint8_t>& data) {
                     strm.next_out = buffer.data();
                     if (inflate(&strm, Z_NO_FLUSH) == Z_STREAM_ERROR) {
                         std::cerr << "Failed to inflate zlib stream" << std::endl;
-                        break;
+                        continue;
                     }
                     decompressed.insert(decompressed.end(), buffer.begin(), buffer.begin() + buffer.size() - strm.avail_out);
                 } while (strm.avail_out == 0);

--- a/wiliwili/source/api/util/ws_utils.cpp
+++ b/wiliwili/source/api/util/ws_utils.cpp
@@ -66,7 +66,7 @@ std::vector<std::string> parse_packet(const std::vector<uint8_t>& data) {
                     strm.next_out = buffer.data();
                     if (inflate(&strm, Z_NO_FLUSH) == Z_STREAM_ERROR) {
                         std::cerr << "Failed to inflate zlib stream" << std::endl;
-                        continue;
+                        break;
                     }
                     decompressed.insert(decompressed.end(), buffer.begin(), buffer.begin() + buffer.size() - strm.avail_out);
                 } while (strm.avail_out == 0);


### PR DESCRIPTION
问题引用：#185 

直播弹幕很少的问题修复了，疏忽导致的 (本来都修好了，新的解析函数导致这个bug还在。。以不一样的原因)
我还做了优化和加了点拓展性。现在直播弹幕的颜色也是正确的了，跟网页端一致

我给弹幕留了拓展的功能，你可以看一下`live_player_activity.cpp`新加的函数`process_danmaku` 和 `extract_messages.hpp` 中的`danmaku_t`类型，如果你想的话，现在已经可以为直播界面添加类似网页端的侧边栏了

还有一些事情，这里提醒你一下：
1. 直播等级0-60级，现有的1-10级屏蔽范围不能满足需求
2. 直播时发送的表情包全部都是文本，在显示端替换成表情的（这种格式：[xxx]）
3. 每个主播的粉丝团表情包不一样，不以括号包裹，单个字或词（啊、哇、biu等）：
> ![屏幕截图 2023-08-02 155410](https://github.com/xfangfang/wiliwili/assets/96584640/33ba34e9-54c7-468b-870d-bf3aa0b2f12f)
4. 其他暂时想不起来了
