### PR TITLE
清理一些 xmake 编译没用到的东西

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -211,7 +211,7 @@ jobs:
         run: |
           $env:path+=";$env:USERPROFILE\xmake"
           $env:XMAKE_GLOBALDIR="${{ runner.temp }}"
-          xmake f -c -y --sw=y --winrt=y --window=sdl --driver=d3d11
+          xmake f -c -y --sw=y --winrt=y --window=sdl --driver=d3d11 -vD
           xmake b -y wiliwili
           cp winrt/key.pfx build/
           cp winrt/docs/key.pdf build/key.pdf

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -190,10 +190,6 @@ jobs:
     needs: [ version ]
     runs-on: windows-2022
     steps:
-      - name: Setup Windows 10 SDK
-        uses: GuillaumeFalourd/setup-windows10-sdk-action@v1.11
-        with:
-          sdk-version: 19041
       - name: Install NSIS
         shell: powershell
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -211,7 +211,7 @@ jobs:
         run: |
           $env:path+=";$env:USERPROFILE\xmake"
           $env:XMAKE_GLOBALDIR="${{ runner.temp }}"
-          xmake f -c -y --sw=y --winrt=y --window=sdl --driver=d3d11 -vD
+          xmake f -c -y --sw=y --winrt=y --window=sdl --driver=d3d11
           xmake b -y wiliwili
           cp winrt/key.pfx build/
           cp winrt/docs/key.pdf build/key.pdf

--- a/wiliwili/source/view/video_view.cpp
+++ b/wiliwili/source/view/video_view.cpp
@@ -740,7 +740,7 @@ void VideoView::showOSD(bool temp) {
 #ifdef __WINRT__
         this->osdLastShowTime = 0xffffffff;
 #else
-        this->osdLastShowTime = std::numeric_limits<std::time_t>::max();
+        this->osdLastShowTime = (std::numeric_limits<std::time_t>::max)();
 #endif
         this->osd_state       = OSDState::ALWAYS_ON;
     }

--- a/xmake.lua
+++ b/xmake.lua
@@ -31,6 +31,8 @@ else
     set_languages("c++17")
 end
 
+add_repositories("zeromake https://github.com/zeromake/xrepo.git dev")
+
 package("borealis")
     set_sourcedir(path.join(os.projectdir(), "library/borealis"))
 
@@ -78,25 +80,6 @@ package("borealis")
         os.cp("library/include/*", package:installdir("include").."/")
         os.rm(package:installdir("include/borealis/extern"))
         os.cp("library/include/borealis/extern/libretro-common", package:installdir("include").."/")
-    end)
-package_end()
-
-package("mongoose")
-    set_urls("https://github.com/xfangfang/mongoose/archive/8a9b6556816cd5ec8b90f451af7bafd93b000b89.zip")
-
-    add_versions("latest", "01baf387a982e0c1ab32b12b41969d9f7ff05b5c834c1bc82a910572c119d115")
-    
-    on_install(function (package)
-        io.writefile("xmake.lua", [[
-            add_rules("mode.debug", "mode.release")
-            target("mongoose")
-                set_kind("$(kind)")
-                add_headerfiles("mongoose.h")
-                add_files("mongoose.c")
-        ]])
-        local configs = {}
-        configs["kind"] = package:config("shared") and "shared" or "static"
-        import("package.tools.xmake").install(package, configs)
     end)
 package_end()
 
@@ -162,7 +145,6 @@ package("mpv")
     end)
 package_end()
 
-add_repositories("zeromake https://github.com/zeromake/xrepo.git")
 if get_config("winrt") then
     add_requires("sdl2", {configs={shared=true,winrt=true}})
     add_requireconfs("**.sdl2", {configs={shared=true,winrt=true}})
@@ -249,11 +231,9 @@ target("wiliwili")
                 import("uwp")(target)
             else
                 for _, pkg in pairs(target:pkgs()) do
-                    if pkg:has_shared() then
-                        for _, f in ipairs(pkg:libraryfiles()) do
-                            if f:endswith(".dll") or f:endswith(".so") then
-                                os.cp(f, target:targetdir().."/")
-                            end
+                    for _, f in ipairs(pkg:libraryfiles()) do
+                        if f:endswith(".dll") or f:endswith(".so") then
+                            os.cp(f, target:targetdir().."/")
                         end
                     end
                 end

--- a/xmake.lua
+++ b/xmake.lua
@@ -31,7 +31,8 @@ else
     set_languages("c++17")
 end
 
-add_repositories("zeromake https://github.com/zeromake/xrepo.git dev")
+-- add_repositories("zeromake https://github.com/zeromake/xrepo.git v0.1.0")
+add_repositories("zeromake https://github.com/zeromake/xrepo.git")
 
 package("borealis")
     set_sourcedir(path.join(os.projectdir(), "library/borealis"))


### PR DESCRIPTION
- GuillaumeFalourd/setup-windows10-sdk-action@v1.11 没有什么意义 windows-2022 里自带 msvc + sdk
- 顺手修改一下 `std::numeric_limits<std::time_t>::max() -> (std::numeric_limits<std::time_t>::max)()` windows 的默认有 `max`, `min` 的 define，要么 `undef max` 要么手动 `()` 包起来。
- add_repositories 添加一个备份链接，使用 git 版本来切换到旧版，用来后面我的 xrepo 更新发现无法编译可以先切换到这个备份
- mongoose 不再内嵌在 xmake.lua 里，内嵌会导致编译了一个内嵌的和一个 xrepo 的……
- xmake 2.8.3 以后如果是通过静态库引用 `sdl` 例如 `sdl_ttf` 会导致 sdl 依赖不在 `target:pkgs()` 里而是在 `sdl_ttf` 里，现在跳过 `pkg:has_shared()` 检查。
- 剩余的更改在 [xrepo/pull/2](https://github.com/zeromake/xrepo/pull/2)。