### PR TITLE
Video residue

### DIFF
--- a/wiliwili/source/activity/dlna_activity.cpp
+++ b/wiliwili/source/activity/dlna_activity.cpp
@@ -18,7 +18,7 @@ using namespace brls::literals;
 DLNAActivity::DLNAActivity() {
     GA("open_dlna")
 
-    SubtitleCore::instance().reset();
+    MPVCore::instance().reset();
 
     ip = brls::Application::getPlatform()->getIpAddress();
     ip = GET_SETTING(SettingItem::DLNA_IP, ip);
@@ -51,6 +51,7 @@ DLNAActivity::DLNAActivity() {
             std::string url = std::string{(char*)data};
             brls::Logger::info("CurrentURI: {}", url);
             brls::sync([this, url]() {
+                MPVCore::instance().reset();
                 video->setTitle("wiliwili/setting/tools/others/dlna"_i18n);
                 video->showOSD(true);
                 MPVCore::instance().setUrl(url);
@@ -60,7 +61,7 @@ DLNAActivity::DLNAActivity() {
             brls::sync([this, name]() { video->setTitle(name); });
         } else if (event == "Stop") {
             brls::sync([this]() {
-                MPVCore::instance().stop();
+                MPVCore::instance().pause();
                 video->showOSD(false);
                 video->setTitle(
                     "wiliwili/setting/tools/others/dlna_waiting"_i18n);

--- a/wiliwili/source/activity/live_player_activity.cpp
+++ b/wiliwili/source/activity/live_player_activity.cpp
@@ -84,8 +84,8 @@ void LiveActivity::setCommonData() {
     LiveDanmaku::instance().connect(
         liveData.roomid, std::stoi(ProgramConfig::instance().getUserID()));
 
-    // 清空字幕
-    SubtitleCore::instance().reset();
+    // 重置播放器
+    MPVCore::instance().reset();
 
     // 清空自定义着色器
     ShaderHelper::instance().clearShader(false);


### PR DESCRIPTION
现在采用的绘制方式是 mpv **按需** 向fbo绘制视频，在需要显示时把这个fbo绘制到屏幕上。这会导致视频停止播放后fbo残留最后一帧画面，在下一个视频加载之初，这样的残留图像就被显示出来了。

在视频播放前调用一次 reset，可以强制mpv输出一次画面，因为在输出时mpv没有在播放视频，所以画面被置为背景色（默认为黑色），就相当于清屏了。