### PR TITLE
修复macOS 构建速度太慢

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -313,6 +313,7 @@ jobs:
         run: |
           brew install create-dmg dylibbundler boost
           brew reinstall webp
+          brew list webp boost
           brew tap xfangfang/wiliwili
           brew install -v mpv-wiliwili
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -295,7 +295,7 @@ jobs:
 
   build-macos:
     needs: [ version ]
-    runs-on: macos-11
+    runs-on: macos-12
     strategy:
       matrix:
         arch: [ IntelChip, AppleSilicon, Universal ]

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -311,7 +311,8 @@ jobs:
       - name: install deps
         if: matrix.arch != 'Universal' || ( matrix.arch == 'Universal' && github.event.inputs.universal_macos == 'true')
         run: |
-          brew install create-dmg dylibbundler webp boost
+          brew install create-dmg dylibbundler boost
+          brew reinstall webp
           brew tap xfangfang/wiliwili
           brew install -v mpv-wiliwili
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -312,7 +312,6 @@ jobs:
         if: matrix.arch != 'Universal' || ( matrix.arch == 'Universal' && github.event.inputs.universal_macos == 'true')
         run: |
           brew install create-dmg dylibbundler boost
-          brew reinstall webp
           brew list webp boost
           brew tap xfangfang/wiliwili
           brew install -v mpv-wiliwili
@@ -335,7 +334,7 @@ jobs:
         if: matrix.arch != 'Universal' || ( matrix.arch == 'Universal' && github.event.inputs.universal_macos == 'true')
         id: compile
         run: |
-          cmake -B build -DPLATFORM_DESKTOP=ON -DCMAKE_BUILD_TYPE=Release -DMAC_${{ matrix.arch }}=ON -DMAC_DOWNLOAD_DYLIB=ON
+          cmake -B build -DPLATFORM_DESKTOP=ON -DCMAKE_BUILD_TYPE=Release -DMAC_${{ matrix.arch }}=ON -DMAC_DOWNLOAD_DYLIB=ON -DCURL_USE_LIBPSL=OFF
           make -C build wiliwili.app -j$(sysctl -n hw.ncpu)
 
       - name: Name

--- a/cmake/macos.cmake
+++ b/cmake/macos.cmake
@@ -18,7 +18,7 @@ if (APPLE)
     if (MAC_DOWNLOAD_DYLIB)
         set(APP_PLATFORM_LIB
                 ${CMAKE_BINARY_DIR}/deps/${MAC_OS_ARCH}/libmpv.2.dylib
-                ${CMAKE_BINARY_DIR}/deps/${MAC_OS_ARCH}/libwebp.7.1.7.dylib
+                ${CMAKE_BINARY_DIR}/deps/${MAC_OS_ARCH}/libwebp.7.1.8.dylib
                 ${CMAKE_BINARY_DIR}/deps/${MAC_OS_ARCH}/libboost_filesystem-mt.dylib)
         if (NOT USE_SYSTEM_CURL)
             list(APPEND APP_PLATFORM_LIB

--- a/scripts/macos_dylib_downloader.sh
+++ b/scripts/macos_dylib_downloader.sh
@@ -6,7 +6,7 @@ set -e
 mkdir -p deps
 
 BASEURL="https://github.com/xfangfang/wiliwili/releases/download/v0.1.0"
-PACKAGE="macos_dylib_ffmpeg6_mpv36_$1.tar.gz"
+PACKAGE="macos_dylib_ffmpeg6_mpv36_r2_$1.tar.gz"
 DOWNLOAD_FLAG="${PACKAGE}.done"
 
 if [ ! -f "${DOWNLOAD_FLAG}" ];then

--- a/scripts/macos_dylib_merge.sh
+++ b/scripts/macos_dylib_merge.sh
@@ -33,7 +33,7 @@ files=(libass.9.dylib
        libtasn1.6.dylib
        libunibreak.5.dylib
        libunistring.5.dylib
-       libwebp.7.1.7.dylib)
+       libwebp.7.1.8.dylib)
 
 for file in "${files[@]}"; do
   echo "$file"

--- a/scripts/macos_dylib_merge.sh
+++ b/scripts/macos_dylib_merge.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 set -e
 
 files=(libass.9.dylib
@@ -35,7 +36,20 @@ files=(libass.9.dylib
        libunistring.5.dylib
        libwebp.7.1.8.dylib)
 
+i=1
 for file in "${files[@]}"; do
-  echo "$file"
+  echo $i "$file"
+  arm64_ret=$(otool -l ./arm64/"$file" | { grep minos || true;} | { grep 11.0 || true;})
+  x86_ret=$(otool -l ./x86_64/"$file" | { grep 10.11 || true;})
+
+  if [ -z "$arm64_ret" ]; then
+      echo -e "\t\033[31m arm64 不满足 11.0 \033[0m"
+  fi
+
+  if [ -z "$x86_ret" ]; then
+      echo -e "\t\033[31m x86_64 不满足 10.11 \033[0m"
+  fi
+
   lipo -create -output ./universal/"$file" ./x86_64/"$file" ./arm64/"$file"
+  ((i++))
 done


### PR DESCRIPTION
貌似是homebrew去除了macos11的支持，boost依赖在安装时没找到bottle重新编译导致的

顺便更新了一下 homebrew-wiliwili 对 macos14的支持，更新boost 1.83.0和 webp 1.3.2