### PR TITLE
New live video url api

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,8 +307,8 @@ sudo dkp-pacman -S switch-glfw switch-libwebp switch-cmake switch-curl devkitA64
 base_url="https://github.com/xfangfang/wiliwili/releases/download/v0.1.0"
 sudo dkp-pacman -U \
     $base_url/switch-libass-0.17.1-1-any.pkg.tar.zst \
-    $base_url/switch-ffmpeg-6.1-1-any.pkg.tar.zst \
-    $base_url/switch-libmpv-0.35.1-4-any.pkg.tar.zst
+    $base_url/switch-ffmpeg-6.1-2-any.pkg.tar.zst \
+    $base_url/switch-libmpv-0.36.0-1-any.pkg.tar.zst
 
 # 4. 可选：安装依赖库 nspmini：https://github.com/StarDustCFW/nspmini
 # (1). 在resources 目录下放置：nsp_forwarder.nsp (如何生成nsp见: scripts/switch-forwarder)

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -31,8 +31,8 @@ done
 base_url="https://github.com/xfangfang/wiliwili/releases/download/v0.1.0"
 sudo dkp-pacman -U \
     $base_url/switch-libass-0.17.1-1-any.pkg.tar.zst \
-    $base_url/switch-ffmpeg-6.1-1-any.pkg.tar.zst \
-    $base_url/switch-libmpv-0.35.1-4-any.pkg.tar.zst
+    $base_url/switch-ffmpeg-6.1-2-any.pkg.tar.zst \
+    $base_url/switch-libmpv-0.36.0-1-any.pkg.tar.zst
 ```
 
 # Acknowledgement

--- a/scripts/build_switch.sh
+++ b/scripts/build_switch.sh
@@ -12,8 +12,8 @@ BASE_URL="https://github.com/xfangfang/wiliwili/releases/download/v0.1.0/"
 PKGS=(
     "switch-libass-0.17.1-1-any.pkg.tar.zst"
     "switch-dav1d-1.2.1-1-any.pkg.tar.zst"
-    "switch-ffmpeg-6.1-1-any.pkg.tar.zst"
-    "switch-libmpv-0.35.1-4-any.pkg.tar.zst"
+    "switch-ffmpeg-6.1-2-any.pkg.tar.zst"
+    "switch-libmpv-0.36.0-1-any.pkg.tar.zst"
     "switch-nspmini-48d4fc2-1-any.pkg.tar.xz"
 )
 for PKG in "${PKGS[@]}"; do

--- a/scripts/build_switch_deko3d.sh
+++ b/scripts/build_switch_deko3d.sh
@@ -14,7 +14,7 @@ PKGS=(
     "libuam-f8c9eef01ffe06334d530393d636d69e2b52744b-1-any.pkg.tar.zst"
     "switch-dav1d-1.2.1-1-any.pkg.tar.zst"
     "switch-libass-0.17.1-1-any.pkg.tar.zst"
-    "switch-ffmpeg-6.1-1-any.pkg.tar.zst"
+    "switch-ffmpeg-6.1-2-any.pkg.tar.zst"
     "switch-libmpv_deko3d-0.35.1-4-any.pkg.tar.zst"
     "switch-nspmini-48d4fc2-1-any.pkg.tar.xz"
 )

--- a/scripts/switch/ffmpeg/PKGBUILD
+++ b/scripts/switch/ffmpeg/PKGBUILD
@@ -7,7 +7,7 @@
 pkgname=switch-ffmpeg
 pkgver=6.1
 commit=ff3429991ec1bac1d1b71215402e3d195162e125
-pkgrel=1
+pkgrel=2
 pkgdesc='ffmpeg port (for Nintendo Switch homebrew development)'
 arch=('any')
 url='https://ffmpeg.org/'
@@ -16,8 +16,9 @@ options=(!strip staticlibs)
 makedepends=('switch-pkg-config' 'dkp-toolchain-vars')
 depends=('switch-zlib' 'switch-bzip2' 'switch-libass' 'switch-libfribidi'
          'switch-freetype' 'switch-harfbuzz' 'switch-mbedtls' 'switch-dav1d')
-source=("https://github.com/FFmpeg/FFmpeg/archive/${commit}.tar.gz" "ffmpeg.patch" "network.patch")
+source=("https://github.com/FFmpeg/FFmpeg/archive/${commit}.tar.gz" "ffmpeg.patch" "network.patch" "ffmpeg_bad_frame.patch")
 sha256sums=(
+ 'SKIP'
  'SKIP'
  'SKIP'
  'SKIP'
@@ -26,8 +27,25 @@ groups=('switch-portlibs')
 
 prepare() {
   cd FFmpeg-$commit
+
+  rm -rf libavutil/hwcontext_tx1.c
+  rm -rf libavutil/hwcontext_tx1.h
+  rm -rf libavutil/nvdec_drv.h
+  rm -rf libavutil/nvhost_ioctl.h
+  rm -rf libavutil/nvjpg_drv.h
+  rm -rf libavutil/nvmap_ioctl.h
+  rm -rf libavutil/tx1.c
+  rm -rf libavutil/tx1.h
+  rm -rf libavutil/tx1_host1x.h
+  rm -rf libavutil/vic_drv.h
+  rm -rf libavutil/clb0b6.h
+  rm -rf libavutil/clc5b0.h
+  rm -rf libavutil/cle7d0.h
+  rm -rf libavcodec/tx1_*
+
   patch -Np1 -i "$srcdir/ffmpeg.patch"
   patch -Np1 -i "$srcdir/network.patch"
+  patch -Np1 -i "$srcdir/ffmpeg_bad_frame.patch"
 }
 
 build() {

--- a/scripts/switch/ffmpeg/ffmpeg_bad_frame.patch
+++ b/scripts/switch/ffmpeg/ffmpeg_bad_frame.patch
@@ -1,0 +1,12 @@
+diff --git a/libavcodec/tx1_h264.c b/libavcodec/tx1_h264.c
+index c45deed971..0335e0e6b5 100644
+--- a/libavcodec/tx1_h264.c
++++ b/libavcodec/tx1_h264.c
+@@ -461,6 +461,7 @@ static int tx1_h264_end_frame(AVCodecContext *avctx) {
+     H264Context            *h = avctx->priv_data;
+     TX1H264DecodeContext *ctx = avctx->internal->hwaccel_priv_data;
+     AVFrame            *frame = ctx->current_frame;
++    if (frame == NULL) return AVERROR_UNKNOWN;
+     FrameDecodeData      *fdd = (FrameDecodeData *)frame->private_ref->data;
+     TX1Frame              *tf = fdd->hwaccel_priv;
+     AVTX1Map       *input_map = (AVTX1Map *)tf->input_map_ref->data;

--- a/scripts/switch/mpv/PKGBUILD
+++ b/scripts/switch/mpv/PKGBUILD
@@ -4,8 +4,8 @@
 
 pkgbasename=libmpv
 pkgname=switch-${pkgbasename}
-pkgver=0.35.1
-pkgrel=4
+pkgver=0.36.0
+pkgrel=1
 pkgdesc='Command line video player (library only)'
 arch=('any')
 url='https://mpv.io/'

--- a/scripts/switch/mpv/mpv.patch
+++ b/scripts/switch/mpv/mpv.patch
@@ -1,5 +1,5 @@
 diff --git a/audio/out/ao.c b/audio/out/ao.c
-index e797ad3f9c..2b4749bb6d 100644
+index a5aa3a9402..6dd0ba6eb2 100644
 --- a/audio/out/ao.c
 +++ b/audio/out/ao.c
 @@ -53,6 +53,7 @@ extern const struct ao_driver audio_out_wasapi;
@@ -22,7 +22,7 @@ index e797ad3f9c..2b4749bb6d 100644
  #if HAVE_COREAUDIO
 diff --git a/audio/out/ao_hos.c b/audio/out/ao_hos.c
 new file mode 100644
-index 0000000000..0e35759dc9
+index 0000000000..42d3793b91
 --- /dev/null
 +++ b/audio/out/ao_hos.c
 @@ -0,0 +1,293 @@
@@ -266,8 +266,8 @@ index 0000000000..0e35759dc9
 +                    bool in = *(bool *)arg;
 +                    vol = !in;
 +                } else {
-+                    ao_control_vol_t *in = (ao_control_vol_t *)arg;
-+                    vol = (in->left + in->right) / 200.0f;
++                    float *in = (float *)arg;
++                    vol = *in / 100.0f;
 +                }
 +
 +                audrvMixSetVolume(&priv->driver, 0, vol);
@@ -282,8 +282,8 @@ index 0000000000..0e35759dc9
 +                    bool *out = (bool *)arg;
 +                    *out = !vol;
 +                } else {
-+                    ao_control_vol_t *out = (ao_control_vol_t *)arg;
-+                    out->left = out->right = vol * 100.0f;
++                    float *out = (float *)arg;
++                    *out = vol * 100.0f;
 +                }
 +            }
 +            break;
@@ -320,7 +320,7 @@ index 0000000000..0e35759dc9
 +    .options_prefix   = "ao-hos",
 +};
 diff --git a/osdep/io.c b/osdep/io.c
-index ec55aa2647..617a31d262 100644
+index 8cd6dede85..a1933888dd 100644
 --- a/osdep/io.c
 +++ b/osdep/io.c
 @@ -62,7 +62,7 @@ bool mp_set_cloexec(int fd)
@@ -375,10 +375,10 @@ index 8e299918ce..c7b08f5273 100644
  #include "common/common.h"
  #include "common/msg.h"
 diff --git a/wscript b/wscript
-index e349d4103e..9200e9344c 100644
+index 82f65b4afa..f177daf41b 100644
 --- a/wscript
 +++ b/wscript
-@@ -405,6 +405,10 @@ iconv support use --disable-iconv.",
+@@ -419,6 +419,10 @@ iconv support use --disable-iconv.",
          'name': 'rubberband-3',
          'desc': 'new engine support for librubberband',
          'func': check_pkg_config('rubberband >= 3.0.0'),
@@ -386,10 +386,10 @@ index e349d4103e..9200e9344c 100644
 +        'name': '--hos',
 +        'desc': 'Horizon OS',
 +        'func': check_statement(['switch.h'], ''),
-     }
- ]
- 
-@@ -491,6 +495,11 @@ audio_output_features = [
+     }, {
+         'name': 'zimg-st428',
+         'desc': 'ZIMG support for ZIMG_TRANSFER_ST428',
+@@ -509,6 +513,11 @@ audio_output_features = [
          'desc': 'WASAPI audio output',
          'deps': 'os-win32 || os-cygwin',
          'func': check_cc(fragment=load_fragment('wasapi.c')),
@@ -402,10 +402,10 @@ index e349d4103e..9200e9344c 100644
  ]
  
 diff --git a/wscript_build.py b/wscript_build.py
-index 16c8cf0895..6e3e6ca054 100644
+index a470808ae5..ae9d689677 100644
 --- a/wscript_build.py
 +++ b/wscript_build.py
-@@ -197,32 +197,22 @@ def build(ctx):
+@@ -234,32 +234,22 @@ def build(ctx):
  
      if ctx.dependency_satisfied('cplayer'):
          main_fn_c = ctx.pick_first_matching_dep([
@@ -438,7 +438,7 @@ index 16c8cf0895..6e3e6ca054 100644
          ( "osdep/subprocess-dummy.c" ),
      ])
  
-@@ -266,6 +256,7 @@ def build(ctx):
+@@ -309,6 +299,7 @@ def build(ctx):
          ( "audio/out/ao_wasapi.c",               "wasapi" ),
          ( "audio/out/ao_wasapi_changenotify.c",  "wasapi" ),
          ( "audio/out/ao_wasapi_utils.c",         "wasapi" ),

--- a/wiliwili/include/activity/live_player_activity.hpp
+++ b/wiliwili/include/activity/live_player_activity.hpp
@@ -38,6 +38,8 @@ private:
     BRLS_BIND(VideoView, video, "fullscreen/video");
 
     bilibili::LiveVideoResult liveData;
+    // 视频超时的时间戳
+    std::chrono::system_clock::time_point videoExpires{};
 
     //更新timeLabel
     MPVEvent::Subscription tl_event_id;

--- a/wiliwili/include/activity/live_player_activity.hpp
+++ b/wiliwili/include/activity/live_player_activity.hpp
@@ -32,6 +32,8 @@ public:
     std::vector<std::string> getQualityDescriptionList();
     int getCurrentQualityIndex();
 
+    void retryRequestData();
+
     ~LiveActivity() override;
 
 private:

--- a/wiliwili/include/activity/live_player_activity.hpp
+++ b/wiliwili/include/activity/live_player_activity.hpp
@@ -17,7 +17,7 @@ public:
 
     explicit LiveActivity(const bilibili::LiveVideoResult& live);
     explicit LiveActivity(int roomid, const std::string& name = "",
-                 const std::string& views = "");
+                          const std::string& views = "");
 
     void setCommonData();
 
@@ -37,9 +37,12 @@ public:
 private:
     BRLS_BIND(VideoView, video, "fullscreen/video");
 
+    // 暂停的延时函数 handle
+    size_t toggleDelayIter = 0;
+    // 遇到错误重试的延时函数 handle
+    size_t errorDelayIter = 0;
+
     bilibili::LiveVideoResult liveData;
-    // 视频超时的时间戳
-    std::chrono::system_clock::time_point videoExpires{};
 
     //更新timeLabel
     MPVEvent::Subscription tl_event_id;

--- a/wiliwili/include/activity/live_player_activity.hpp
+++ b/wiliwili/include/activity/live_player_activity.hpp
@@ -25,7 +25,8 @@ public:
 
     void onContentAvailable() override;
 
-    void onLiveData(const bilibili::LiveUrlResultWrapper& result) override;
+    void onLiveData(const bilibili::LiveRoomPlayInfo& result) override;
+
     void onError(const std::string& error) override;
 
     std::vector<std::string> getQualityDescriptionList();

--- a/wiliwili/include/api/bilibili.h
+++ b/wiliwili/include/api/bilibili.h
@@ -10,6 +10,7 @@ namespace bilibili {
 
 class LiveResultWrapper;
 class LiveUrlResultWrapper;
+class LiveRoomPlayInfo;
 class LiveFullAreaResultWrapper;  // 直播分区列表
 class LiveSecondResultWrapper;    // 直播二级分区推荐
 class SearchResult;
@@ -284,9 +285,15 @@ public:
         const ErrorCallback& error                          = nullptr);
 
     /// get live video url by roomid
+    /// @deprecated 部分直播间可能无法获取到直播地址，但可以获取到长时间有效的直播地址
     static void get_live_url(
         int roomid, int qn = 10000,
         const std::function<void(LiveUrlResultWrapper)>& callback = nullptr,
+        const ErrorCallback& error                                = nullptr);
+
+    static void get_live_room_play_info(
+        int roomid, int qn = 0,
+        const std::function<void(LiveRoomPlayInfo)>& callback = nullptr,
         const ErrorCallback& error                                = nullptr);
 
     /**

--- a/wiliwili/include/api/bilibili/api.h
+++ b/wiliwili/include/api/bilibili/api.h
@@ -101,6 +101,9 @@ const std::string VideoEpisodeRelation =
 const std::string VideoDanmaku = _apiBase + "/x/v1/dm/list.so";
 /// 直播API
 const std::string LiveUrl = _liveBase + "/room/v1/Room/playUrl";
+/// 直播API V2
+const std::string RoomPlayInfo =
+    _liveBase + "/xlive/web-room/v2/index/getRoomPlayInfo";
 /// 直播历史记录
 const std::string LiveReport =
     _liveBase + "/xlive/web-room/v1/index/roomEntryAction";

--- a/wiliwili/include/api/bilibili/result/home_live_result.h
+++ b/wiliwili/include/api/bilibili/result/home_live_result.h
@@ -35,6 +35,75 @@ public:
 };
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(LiveUrlResultWrapper, current_qn, durl,
                                    quality_description);
+class LiveQnDesc {
+public:
+    int qn;
+    std::string desc;
+};
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(LiveQnDesc, qn, desc);
+
+class LiveStreamUrlInfo {
+public:
+    std::string host;
+    std::string extra;
+    int stream_ttl;
+};
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(LiveStreamUrlInfo, host, extra, stream_ttl);
+
+class LiveStreamFormatCodec {
+public:
+    std::string codec_name;
+    int current_qn;
+    std::vector<int> accept_qn;
+    std::string base_url;
+    std::vector<LiveStreamUrlInfo> url_info;
+};
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(LiveStreamFormatCodec, codec_name,
+                                   current_qn, accept_qn, base_url, url_info);
+
+class LiveStreamFormat {
+public:
+    std::string format_name;
+    std::vector<LiveStreamFormatCodec> codec;
+};
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(LiveStreamFormat, format_name, codec);
+
+class LiveStream {
+public:
+    std::string protocol_name;
+    std::vector<LiveStreamFormat> format;
+};
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(LiveStream, protocol_name, format);
+
+class LivePlayUrl {
+public:
+    std::vector<LiveQnDesc> g_qn_desc;
+    std::vector<LiveStream> stream;
+};
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(LivePlayUrl, g_qn_desc, stream);
+
+class LivePlayUrlInfo {
+public:
+    LivePlayUrl playurl;
+};
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(LivePlayUrlInfo, playurl);
+
+class LiveRoomPlayInfo {
+public:
+    int room_id;
+    int64_t uid;
+    int live_status;
+    size_t live_time;
+    LivePlayUrlInfo playurl_info;
+};
+inline void from_json(const nlohmann::json& nlohmann_json_j,
+                      LiveRoomPlayInfo& nlohmann_json_t) {
+    if (!nlohmann_json_j.at("playurl_info").is_null()) {
+        nlohmann_json_j.at("playurl_info").get_to(nlohmann_json_t.playurl_info);
+    }
+    NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_FROM, room_id, uid,
+                                             live_status, live_time));
+}
 
 class LiveAreaResult {
 public:

--- a/wiliwili/include/api/live/danmaku_live.hpp
+++ b/wiliwili/include/api/live/danmaku_live.hpp
@@ -32,8 +32,6 @@ public:
     void set_wait_time(size_t time);
     size_t wait_time = 800;
 
-    size_t live_time = 0;
-
     LiveDanmaku();
     ~LiveDanmaku();
 

--- a/wiliwili/include/api/live/danmaku_live.hpp
+++ b/wiliwili/include/api/live/danmaku_live.hpp
@@ -19,9 +19,9 @@ class LiveDanmaku : public brls::Singleton<LiveDanmaku> {
 public:
     int room_id;
     int uid;
-    void connect(int room_id, int uid);
+    void connect(int room_id, int64_t uid);
     void disconnect();
-    void send_join_request(int room_id, int uid);
+    void send_join_request(int room_id, int64_t uid);
 
     void send_heartbeat();
     void send_text_message(const std::string &message);

--- a/wiliwili/include/presenter/live_data.hpp
+++ b/wiliwili/include/presenter/live_data.hpp
@@ -12,18 +12,42 @@
 
 class LiveDataRequest : public Presenter {
 public:
-    virtual void onLiveData(const bilibili::LiveUrlResultWrapper& result) {}
+    virtual void onLiveData(const bilibili::LiveRoomPlayInfo& result) {}
 
     virtual void onError(const std::string& error) {}
 
     void requestData(int roomid) {
         ASYNC_RETAIN
-        BILI::get_live_url(
+        BILI::get_live_room_play_info(
             roomid, defaultQuality,
-            [ASYNC_TOKEN](const bilibili::LiveUrlResultWrapper& result) {
+            [ASYNC_TOKEN](const auto& result) {
                 ASYNC_RELEASE
-                liveUrl = result;
-                onLiveData(result);
+                liveRoomPlayInfo = result;
+                qualityDescriptionMap.clear();
+                for (auto& i :
+                     liveRoomPlayInfo.playurl_info.playurl.g_qn_desc) {
+                    qualityDescriptionMap[i.qn] = i.desc;
+                }
+
+                // 选择第一个 protocol 的 第一个 format 的第一个 codec 作为播放源
+                // protocol: http_stream / http_hls
+                // format: flv / ts / fmp4
+                // codec: avc / hevc / av1
+                bilibili::LiveStream stream;
+                for (auto& i : liveRoomPlayInfo.playurl_info.playurl.stream) {
+                    stream = i;
+                    break;
+                }
+                bilibili::LiveStreamFormat format;
+                for (auto& i : stream.format) {
+                    format = i;
+                    break;
+                }
+                for (auto& i : format.codec) {
+                    liveUrl = i;
+                    break;
+                }
+                onLiveData(liveRoomPlayInfo);
             },
             [ASYNC_TOKEN](BILI_ERR) {
                 ASYNC_RELEASE
@@ -45,6 +69,14 @@ public:
             [this](BILI_ERR) { this->onError(error); });
     }
 
-    static inline int defaultQuality = 10000;
-    bilibili::LiveUrlResultWrapper liveUrl;
+    std::string getQualityDescription(int qn) {
+        if (qualityDescriptionMap.count(qn) == 0)
+            return "Unknown Quality " + std::to_string(qn);
+        return qualityDescriptionMap[qn];
+    }
+
+    static inline int defaultQuality = 0;
+    bilibili::LiveRoomPlayInfo liveRoomPlayInfo;
+    bilibili::LiveStreamFormatCodec liveUrl;
+    std::unordered_map<int, std::string> qualityDescriptionMap;
 };

--- a/wiliwili/include/presenter/live_data.hpp
+++ b/wiliwili/include/presenter/live_data.hpp
@@ -50,8 +50,10 @@ public:
                 onLiveData(liveRoomPlayInfo);
             },
             [ASYNC_TOKEN](BILI_ERR) {
-                ASYNC_RELEASE
-                this->onError(error);
+                brls::sync([ASYNC_TOKEN, error]() {
+                    ASYNC_RELEASE
+                    this->onError(error);
+                });
             });
 
         reportHistory(roomid);
@@ -66,7 +68,9 @@ public:
             [roomid]() {
                 brls::Logger::debug("report live history {}", roomid);
             },
-            [this](BILI_ERR) { this->onError(error); });
+            [](BILI_ERR) {
+                brls::Logger::error("report live history:", error);
+            });
     }
 
     std::string getQualityDescription(int qn) {

--- a/wiliwili/include/view/mpv_core.hpp
+++ b/wiliwili/include/view/mpv_core.hpp
@@ -69,6 +69,8 @@ public:
 
     bool isStopped() const;
 
+    bool isPlaying() const;
+
     bool isPaused() const;
 
     double getSpeed() const;
@@ -226,6 +228,8 @@ public:
     bool video_paused      = false;
     bool video_stopped     = true;
     bool video_seeking     = false;
+    bool video_playing     = false;
+    bool video_eof         = false;
     double playback_time   = 0;
     double percent_pos     = 0;
     int64_t video_progress = 0;

--- a/wiliwili/include/view/mpv_core.hpp
+++ b/wiliwili/include/view/mpv_core.hpp
@@ -229,6 +229,7 @@ public:
     double playback_time   = 0;
     double percent_pos     = 0;
     int64_t video_progress = 0;
+    int mpv_error_code     = 0;
 
     // 低画质解码，剔除解码过程中的部分步骤，可以用来节省cpu
     inline static bool LOW_QUALITY = false;

--- a/wiliwili/source/activity/live_player_activity.cpp
+++ b/wiliwili/source/activity/live_player_activity.cpp
@@ -84,7 +84,7 @@ LiveActivity::LiveActivity(int roomid, const std::string& name,
 
 void LiveActivity::setCommonData() {
     LiveDanmaku::instance().connect(
-        liveData.roomid, std::stoi(ProgramConfig::instance().getUserID()));
+        liveData.roomid, std::stoll(ProgramConfig::instance().getUserID()));
 
     // 重置播放器
     MPVCore::instance().reset();
@@ -118,7 +118,8 @@ void LiveActivity::setCommonData() {
                     this->video->setOnlineCount("加载失败");
                     // 加载失败时，获取直播间信息，查看是否直播间已经关闭
                     // 如果直播间信息获取失败，则认定为断网，每隔N秒重试一次
-                    this->requestData(liveData.roomid);
+                    this->retryRequestData();
+                    break;
                 default:
                     this->video->setOnlineCount(
                         {mpv_error_string(MPVCore::instance().mpv_error_code)});

--- a/wiliwili/source/api/danmaku_live.cpp
+++ b/wiliwili/source/api/danmaku_live.cpp
@@ -99,7 +99,7 @@ LiveDanmaku::~LiveDanmaku() {
 #endif
 }
 
-void LiveDanmaku::connect(int room_id, int uid) {
+void LiveDanmaku::connect(int room_id, int64_t uid) {
     if (connected.load(std::memory_order_acquire)) {
         return;
     }
@@ -193,7 +193,7 @@ bool LiveDanmaku::is_connected() {
 
 bool LiveDanmaku::is_evOK() { return ms_ev_ok.load(std::memory_order_acquire); }
 
-void LiveDanmaku::send_join_request(const int room_id, const int uid) {
+void LiveDanmaku::send_join_request(const int room_id, const int64_t uid) {
     json join_request = {
         {"uid", uid},        {"roomid", room_id},
         {"protover", 2},     {"buvid", ProgramConfig::instance().getBuvid3()},

--- a/wiliwili/source/api/danmaku_live.cpp
+++ b/wiliwili/source/api/danmaku_live.cpp
@@ -24,7 +24,7 @@ using json = nlohmann::json;
 static std::string url = "ws://broadcastlv.chat.bilibili.com:2244/sub";
 static std::string key = "";
 
-static void get_live_s(int room_id, size_t *live_time) {
+static void get_live_s(int room_id) {
     auto res = bilibili::HTTP::get(
         "https://api.live.bilibili.com/xlive/web-room/v1/index/"
         "getDanmuInfo?type=0&id=" +
@@ -48,39 +48,6 @@ static void get_live_s(int room_id, size_t *live_time) {
             //           _json["data"]["host_list"][0]["ws_port"].get<int>()) +
             //       "/sub";
             key = _json["data"]["token"].get_ref<const std::string &>();
-        }
-    }
-
-    auto res2 = bilibili::HTTP::get(
-        "https://api.live.bilibili.com/room/v1/Room/get_info?room_id=" +
-        std::to_string(room_id));
-
-    if (res2.status_code != 200) {
-        brls::Logger::error("get_info error:{}", res2.status_code);
-    } else {
-        json _json;
-        try {
-            _json = json::parse(res2.text);
-        } catch (const std::exception &e) {
-            std::cout << "room_init json parse error" << std::endl;
-        }
-        if (_json["code"].get<int>() == 0) {
-            //YYYY-MM-DD HH:mm:ss
-            std::string time_str =
-                _json["data"]["live_time"].get_ref<std::string &>();
-            struct tm tm = {};
-            std::istringstream ss(time_str);
-            ss >> std::get_time(&tm, "%Y-%m-%d %H:%M:%S");
-            if (ss.fail()) {
-                brls::Logger::error("get live_time error");
-                return;
-            }
-            std::time_t time = std::mktime(&tm);
-            if (time == -1) {
-                brls::Logger::error("get live_time error");
-                return;
-            }
-            *live_time = (size_t)time;
         }
     }
 }
@@ -145,7 +112,7 @@ void LiveDanmaku::connect(int room_id, int uid) {
         return;
     }
 
-    get_live_s(room_id, &this->live_time);
+    get_live_s(room_id);
 
     mg_log_set(MG_LL_NONE);
     mg_mgr_init(this->mgr);

--- a/wiliwili/source/api/video_detail_api.cpp
+++ b/wiliwili/source/api/video_detail_api.cpp
@@ -205,6 +205,25 @@ void BilibiliClient::get_live_url(
                                                callback, error);
 }
 
+void BilibiliClient::get_live_room_play_info(
+    int roomid, int qn, const std::function<void(LiveRoomPlayInfo)>& callback,
+    const ErrorCallback& error) {
+    HTTP::getResultAsync<LiveRoomPlayInfo>(
+        Api::RoomPlayInfo,
+        {{"room_id", std::to_string(roomid)},
+         {"no_playurl", "0"},
+         {"mask", "1"},
+         {"qn", std::to_string(qn)},
+         {"platform", "web"},
+         {"protocol", "0,1"},
+         {"format", "0,1,2"},
+         {"codec", "0,1,2"},
+         {"dolby", "5"},
+         {"ptype", "8"},
+         {"panorama", "1"}},
+        callback, error);
+}
+
 /// 视频页 获取单个视频播放人数
 void BilibiliClient::get_video_online(
     int aid, int cid, const std::function<void(VideoOnlineTotal)>& callback,

--- a/wiliwili/source/view/danmaku_core.cpp
+++ b/wiliwili/source/view/danmaku_core.cpp
@@ -41,7 +41,7 @@ DanmakuItem::DanmakuItem(std::string content, const char *attributes)
     // 判断是否添加浅色边框
     if ((r * 299 + g * 587 + b * 114) < 60000) {
         borderColor   = nvgRGB(255, 255, 255);
-        borderColor.a = DanmakuCore::DANMAKU_STYLE_ALPHA * 0.5;
+        borderColor.a = DanmakuCore::DANMAKU_STYLE_ALPHA * 0.005;
     }
 }
 

--- a/wiliwili/source/view/live_core.cpp
+++ b/wiliwili/source/view/live_core.cpp
@@ -115,10 +115,10 @@ void LiveDanmakuCore::draw(NVGcontext *vg, float x, float y, float width,
         NVGcolor color = nvgRGB(r, g, b);
         color.a        = DanmakuCore::DANMAKU_STYLE_ALPHA * 0.01 * alpha;
         NVGcolor border_color =
-            nvgRGBA(0, 0, 0, DanmakuCore::DANMAKU_STYLE_ALPHA * 0.005 * alpha);
+            nvgRGBA(0, 0, 0, DanmakuCore::DANMAKU_STYLE_ALPHA * 1.28 * alpha);
         if ((r * 299 + g * 587 + b * 114) < 60000) {
             border_color = nvgRGBA(
-                255, 255, 255, DanmakuCore::DANMAKU_STYLE_ALPHA * 0.5 * alpha);
+                255, 255, 255, DanmakuCore::DANMAKU_STYLE_ALPHA * 1.28 * alpha);
         }
 
         nvgFillColor(vg, border_color);

--- a/wiliwili/source/view/mpv_core.cpp
+++ b/wiliwili/source/view/mpv_core.cpp
@@ -701,6 +701,7 @@ void MPVCore::eventMainLoop() {
                 disableDimming(false);
                 auto node = (mpv_event_end_file *)event->data;
                 if (node->reason == MPV_END_FILE_REASON_ERROR) {
+                    mpv_error_code = node->error;
                     brls::Logger::error("========> MPV ERROR: {}",
                                         mpv_error_string(node->error));
                     mpvCoreEvent.fire(MpvEventEnum::MPV_FILE_ERROR);
@@ -887,6 +888,7 @@ void MPVCore::reset() {
     this->cache_speed    = 0;  // Bps
     this->playback_time  = 0;
     this->video_progress = 0;
+    this->mpv_error_code = 0;
 
     // 软硬解切换后应该手动设置一次渲染尺寸
     // 切换视频前设置渲染尺寸可以顺便将上一条视频的最后一帧画面清空

--- a/wiliwili/source/view/mpv_core.cpp
+++ b/wiliwili/source/view/mpv_core.cpp
@@ -677,6 +677,7 @@ void MPVCore::eventMainLoop() {
             case MPV_EVENT_PLAYBACK_RESTART:
                 // event 21: 开始播放文件（一般是播放或调整进度结束之后触发）
                 brls::Logger::info("========> MPV_EVENT_PLAYBACK_RESTART");
+                video_stopped = false;
                 mpvCoreEvent.fire(MpvEventEnum::LOADING_END);
                 if (AUTO_PLAY) {
                     mpvCoreEvent.fire(MpvEventEnum::MPV_RESUME);

--- a/wiliwili/source/view/mpv_core.cpp
+++ b/wiliwili/source/view/mpv_core.cpp
@@ -661,6 +661,9 @@ void MPVCore::eventMainLoop() {
                 brls::Logger::info("========> MPV_EVENT_FILE_LOADED");
                 // event 8: 文件预加载结束，准备解码
                 mpvCoreEvent.fire(MpvEventEnum::MPV_LOADED);
+                // 发布一次进度更新事件，避免进度条在0秒时没有进度更新
+                video_progress = 0;
+                mpvCoreEvent.fire(MpvEventEnum::UPDATE_PROGRESS);
                 // 移除其他备用链接
                 command_async("playlist-clear");
                 break;

--- a/wiliwili/source/view/video_view.cpp
+++ b/wiliwili/source/view/video_view.cpp
@@ -204,11 +204,7 @@ VideoView::VideoView() {
                             int64_t current_time = getCPUTimeUsec();
                             if (current_time - press_time < CHECK_TIME) {
                                 // 双击切换播放状态
-                                if (mpvCore->isPaused()) {
-                                    mpvCore->resume();
-                                } else {
-                                    mpvCore->pause();
-                                }
+                                togglePlay();
                                 click_state = ClickState::IDLE;
                             } else {
                                 // 单击切换 OSD，设置一个延迟用来等待双击结果

--- a/wiliwili/source/view/video_view.cpp
+++ b/wiliwili/source/view/video_view.cpp
@@ -78,7 +78,10 @@ VideoView::VideoView() {
         [this](brls::View* view) -> bool {
             ControllerState state{};
             input->updateUnifiedControllerState(&state);
-            if (state.buttons[BUTTON_Y]) {
+            bool buttonY = brls::Application::isSwapInputKeys()
+                               ? state.buttons[BUTTON_X]
+                               : state.buttons[BUTTON_Y];
+            if (buttonY) {
                 seeking_range -= getSeekRange(seeking_range);
             } else {
                 seeking_range += getSeekRange(seeking_range);
@@ -229,10 +232,7 @@ VideoView::VideoView() {
 
     /// 播放/暂停 按钮
     this->btnToggle->addGestureRecognizer(new brls::TapGestureRecognizer(
-        this->btnToggle,
-        [this]() {
-            this->togglePlay();
-        },
+        this->btnToggle, [this]() { this->togglePlay(); },
         brls::TapGestureConfig(false, brls::SOUND_NONE, brls::SOUND_NONE,
                                brls::SOUND_NONE)));
 

--- a/wiliwili/source/view/video_view.cpp
+++ b/wiliwili/source/view/video_view.cpp
@@ -1061,6 +1061,7 @@ void VideoView::buttonProcessing() {
 
     static int click_state        = ClickState::IDLE;
     static int64_t rsb_press_time = 0;
+    if (isLiveMode) return;
     if (click_state == ClickState::IDLE && !state.buttons[BUTTON_RSB]) return;
 
     int CHECK_TIME = 200000;


### PR DESCRIPTION
待完成的事：
- [x] 我还没测试，但是貌似新的接口获取的视频链接是有时效性的（一个小时？）所以需要定时刷新链接
- [x] 完善未开播等错误的判断

- - - 
直播视频链接有效期 1小时，但是如果没有遇到故障就能一直使用。在遇到报错时（视频无法播放），只要不是视频格式不支持，就每隔2s重复获取直播间信息，直到直播间信息刷新（获取到新的链接或者确认直播间已经关闭）。

- - -
23/11/10 注意到一个现象，当修改了获取直播链接的格式，比如默认获取的链接是flv，改为只获取hls。获取到的m3u8链接会报错404，同一个链接再播放两次或者重新获取一次链接就能正常使用。可能是B站会对非默认格式做限流，使用的人多了之后才会启用。
所以使用默认获取的链接即可。

23/11/13 前面的现象消失了

---
顺便，将直播弹幕的用户id从 int 改为 int64。新用户都是长id了，int 存不下。
