### PR TITLE
Move disableDimming to VideoView

### DIFF
--- a/wiliwili/include/view/mpv_core.hpp
+++ b/wiliwili/include/view/mpv_core.hpp
@@ -151,11 +151,6 @@ public:
     void showOsdText(const std::string &value, int duration = 2000);
 
     /**
-     * 禁用系统锁屏
-     */
-    static void disableDimming(bool disable);
-
-    /**
      * 绘制视频
      *
      * 支持三种绘制方式 （通过编译参数切换）

--- a/wiliwili/include/view/video_view.hpp
+++ b/wiliwili/include/view/video_view.hpp
@@ -276,4 +276,9 @@ private:
      * seeking_range: 相对进度，单位秒
      */
     void requestSeeking();
+
+    /**
+     * 禁用系统锁屏
+     */
+    static void disableDimming(bool disable);
 };


### PR DESCRIPTION
参考文档中 [MPV_EVENT_SEEK](https://mpv.io/manual/stable/#command-interface-mpv-event-seek)，简化了部分 mpv 事件订阅

`disableDimming` 转移到 `VideoView` 中的 `showLoading/hideLoading` 中调用，减少了 `disableDimming` 到处调用的情况 