### PR TITLE
feats: add create win32 minidump

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -104,14 +104,12 @@ jobs:
           mv ${{ needs.version.outputs.DIST_FLATPAK_X86_64 }}/wiliwili-Linux-${{ needs.version.outputs.version }}.flatpak \
             ${{ needs.version.outputs.DIST_FLATPAK_X86_64 }}/${{ needs.version.outputs.DIST_FLATPAK_X86_64 }}.flatpak
 
-      - name: Rename exe
+      - name: Package exe
         if: github.event.inputs.release == 'true' && !cancelled()
         run: |
           tree
-          mv ${{ needs.version.outputs.DIST_EXE }}-d3d-x86_64/${{ needs.version.outputs.DIST_EXE }}-d3d-x86_64.zip \
-             ${{ needs.version.outputs.DIST_EXE }}-x86_64.zip
-          mv ${{ needs.version.outputs.DIST_EXE }}-d3d-x86/${{ needs.version.outputs.DIST_EXE }}-d3d-x86.zip \
-             ${{ needs.version.outputs.DIST_EXE }}-x86.zip
+          zip -r -9 ${{ needs.version.outputs.DIST_EXE }}-x86_64.zip ${{ needs.version.outputs.DIST_EXE }}-d3d-x86_64
+          zip -r -9 ${{ needs.version.outputs.DIST_EXE }}-x86.zip ${{ needs.version.outputs.DIST_EXE }}-d3d-x86
 
       - name: Upload Release
         if: github.event.inputs.release == 'true' && !cancelled()
@@ -161,10 +159,13 @@ jobs:
         run: |
           pacman -S --needed --noconfirm --noprogressbar \
             ${MINGW_PACKAGE_PREFIX}-gcc \
-            ${MINGW_PACKAGE_PREFIX}-ninja
+            ${MINGW_PACKAGE_PREFIX}-ninja unzip
 
           curl -LO https://github.com/xfangfang/wiliwili/releases/download/v0.1.0/${MINGW_PACKAGE_PREFIX}-mpv-0.36.0-4-any.pkg.tar.zst
           pacman -U --noconfirm *.pkg.tar.zst
+
+          curl -LO https://github.com/rainers/cv2pdb/releases/download/v0.52/cv2pdb-0.52.zip
+          unzip cv2pdb-0.52.zip cv2pdb64.exe -d /usr/bin
       - if: matrix.arch == 'x86'
         name: Config Editbin
         shell: powershell
@@ -198,7 +199,7 @@ jobs:
       - name: Build
         run: |
           cmake -B build -G Ninja ${{ matrix.cmake }} \
-            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
             -DPLATFORM_DESKTOP=ON \
             -DWIN32_TERMINAL=OFF \
             -DCURL_DISABLE_PROGRESS_METER=ON \
@@ -213,14 +214,16 @@ jobs:
             -DMPV_BUNDLE_DLL=${MINGW_PREFIX}/bin/libmpv-2.dll \
             -DVERSION_BUILD=${{ github.run_number }}
           cmake --build build
-          strip build/wiliwili.exe
-          7z a -mx=9 -tzip ${{ needs.version.outputs.DIST_EXE }}-${{ matrix.driver }}-${{ matrix.arch }}.zip \
-            ./build/wiliwili.exe README.md 
+          cv2pdb64 build/wiliwili.exe
+          cp -a README.md build
       - name: Upload dist
         uses: actions/upload-artifact@v4
         with:
           name: ${{ needs.version.outputs.DIST_EXE }}-${{ matrix.driver }}-${{ matrix.arch }}
-          path: "${{ needs.version.outputs.DIST_EXE }}-${{ matrix.driver }}-${{ matrix.arch }}.zip"
+          path: |
+            build/wiliwili.exe
+            build/wiliwili.pdb
+            build/README.md
 
   build-win-uwp:
     needs: [ version ]

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ libromfs-generator
 build-*
 android-project
 *.deb
+*.dmp

--- a/wiliwili/include/utils/crash_helper.hpp
+++ b/wiliwili/include/utils/crash_helper.hpp
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace wiliwili {
+
+void initCrashDump();
+
+}

--- a/wiliwili/source/utils/config_helper.cpp
+++ b/wiliwili/source/utils/config_helper.cpp
@@ -17,6 +17,7 @@
 #include "utils/thread_helper.hpp"
 #include "utils/image_helper.hpp"
 #include "utils/config_helper.hpp"
+#include "utils/crash_helper.hpp"
 #include "utils/vibration_helper.hpp"
 #include "utils/ban_list.hpp"
 #include "utils/string_helper.hpp"
@@ -709,6 +710,7 @@ void ProgramConfig::save() {
 
 void ProgramConfig::init() {
     brls::Logger::info("wiliwili {}", APPVersion::instance().git_tag);
+    wiliwili::initCrashDump();
 
     // Set min_threads and max_threads of http thread pool
     curl_global_init(CURL_GLOBAL_DEFAULT);

--- a/wiliwili/source/utils/crash_helper.cpp
+++ b/wiliwili/source/utils/crash_helper.cpp
@@ -1,0 +1,123 @@
+#include "utils/crash_helper.hpp"
+#include <borealis/core/logger.hpp>
+
+#if defined(_WIN32) && !defined(__WINRT__)
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <dbghelp.h>
+
+LONG WINAPI createMiniDump(_EXCEPTION_POINTERS* pep) {
+    MEMORY_BASIC_INFORMATION memInfo;
+    PEXCEPTION_RECORD xcpt = pep->ExceptionRecord;
+    HANDLE hProcess        = ::GetCurrentProcess();
+    HANDLE hThread         = ::GetCurrentThread();
+    brls::Logger::error("Exception code {:#x}", xcpt->ExceptionCode);
+
+    if (::VirtualQuery(xcpt->ExceptionAddress, &memInfo, sizeof(memInfo))) {
+        char modulePath[MAX_PATH] = "Unknown Module";
+        HMODULE hModule           = (HMODULE)memInfo.AllocationBase;
+        if (!memInfo.AllocationBase) hModule = GetModuleHandleA(nullptr);
+        ::GetModuleFileNameA(hModule, modulePath, sizeof(modulePath));
+        brls::Logger::error("Fault address {} {}", fmt::ptr(xcpt->ExceptionAddress), modulePath);
+    }
+
+    // Get handles to kernel32 and dbghelp
+    HMODULE dbghelp = ::LoadLibraryA("dbghelp.dll");
+    if (!dbghelp) return EXCEPTION_CONTINUE_SEARCH;
+
+    auto fnMiniDumpWriteDump = (WINBOOL(WINAPI*)(HANDLE, DWORD, HANDLE, MINIDUMP_TYPE,
+        CONST PMINIDUMP_EXCEPTION_INFORMATION, CONST PMINIDUMP_USER_STREAM_INFORMATION,
+        CONST PMINIDUMP_CALLBACK_INFORMATION))::GetProcAddress(dbghelp, "MiniDumpWriteDump");
+    auto fnSymInitialize = (WINBOOL(WINAPI*)(HANDLE, PCSTR, WINBOOL))::GetProcAddress(dbghelp, "SymInitialize");
+    auto fnSymCleanup = (WINBOOL(WINAPI*)(HANDLE))::GetProcAddress(dbghelp, "SymCleanup");
+    auto fnSymSetOptions = (DWORD(WINAPI*)(DWORD))::GetProcAddress(dbghelp, "SymSetOptions");
+    auto fnStackWalk64 = (WINBOOL(WINAPI*)(DWORD, HANDLE, HANDLE, LPSTACKFRAME64, PVOID, PREAD_PROCESS_MEMORY_ROUTINE64,
+        PFUNCTION_TABLE_ACCESS_ROUTINE64, PGET_MODULE_BASE_ROUTINE64, PTRANSLATE_ADDRESS_ROUTINE64))::GetProcAddress(dbghelp, "StackWalk64");
+    auto fnSymGetSymFromAddr64 = (WINBOOL(WINAPI*)(HANDLE, DWORD64, PDWORD64, PIMAGEHLP_SYMBOL64))::GetProcAddress(dbghelp, "SymGetSymFromAddr64");
+    auto fnSymGetLineFromAddr64 = (WINBOOL(WINAPI*)(HANDLE, DWORD64, PDWORD, PIMAGEHLP_LINE64))::GetProcAddress(dbghelp, "SymGetLineFromAddr64");
+    auto fnSymGetModuleInfo64 = (WINBOOL(WINAPI*)(HANDLE, DWORD64, PIMAGEHLP_MODULE64))::GetProcAddress(dbghelp, "SymGetModuleInfo64");
+    auto fnSymFTA64 = (PFUNCTION_TABLE_ACCESS_ROUTINE64)::GetProcAddress(dbghelp, "SymFunctionTableAccess64");
+    auto fnSymGMB64 = (PGET_MODULE_BASE_ROUTINE64)::GetProcAddress(dbghelp, "SymGetModuleBase64");
+
+    STACKFRAME64 s;
+    DWORD imageType;
+    CONTEXT ctx = *pep->ContextRecord;
+
+    ZeroMemory(&s, sizeof(s));
+    s.AddrPC.Mode    = AddrModeFlat;
+    s.AddrFrame.Mode = AddrModeFlat;
+    s.AddrStack.Mode = AddrModeFlat;
+#ifdef _M_IX86
+    imageType          = IMAGE_FILE_MACHINE_I386;
+    s.AddrPC.Offset    = ctx.Eip;
+    s.AddrFrame.Offset = ctx.Ebp;
+    s.AddrStack.Offset = ctx.Esp;
+#elif _M_X64
+    imageType          = IMAGE_FILE_MACHINE_AMD64;
+    s.AddrPC.Offset    = ctx.Rip;
+    s.AddrFrame.Offset = ctx.Rsp;
+    s.AddrStack.Offset = ctx.Rsp;
+#elif _M_ARM64
+    imageType          = IMAGE_FILE_MACHINE_ARM64;
+    s.AddrPC.Offset    = ctx.Pc;
+    s.AddrFrame.Offset = ctx.Fp;
+    s.AddrStack.Offset = ctx.Sp;
+#else
+#error "Platform not supported!"
+#endif
+
+    std::vector<char> buf(sizeof(IMAGEHLP_SYMBOL64) + MAX_SYM_NAME);
+    PIMAGEHLP_SYMBOL64 symbol = reinterpret_cast<PIMAGEHLP_SYMBOL64>(buf.data());
+    symbol->SizeOfStruct      = sizeof(IMAGEHLP_SYMBOL64);
+    symbol->MaxNameLength     = MAX_SYM_NAME;
+    int n                     = 0;
+
+    if (!fnSymInitialize(hProcess, nullptr, TRUE)) {
+        brls::Logger::warning("SymInitialize failed {}", ::GetLastError());
+    }
+    fnSymSetOptions(SYMOPT_UNDNAME | SYMOPT_LOAD_LINES);
+    while (fnStackWalk64(imageType, hProcess, hThread, &s, &ctx, nullptr, fnSymFTA64, fnSymGMB64, nullptr)) {
+        IMAGEHLP_LINE64 line = {sizeof(IMAGEHLP_LINE64)};
+        IMAGEHLP_MODULE64 mi = {sizeof(IMAGEHLP_MODULE64)};
+        DWORD64 funcOffset   = 0;
+        DWORD lineOffset     = 0;
+
+        if (!fnSymGetModuleInfo64(hProcess, s.AddrPC.Offset, &mi)) {
+            strcpy(mi.ImageName, "???");
+        }
+        if (fnSymGetLineFromAddr64(hProcess, s.AddrPC.Offset, &lineOffset, &line)) {
+            brls::Logger::error("[{}]: {}({})", n, line.FileName, line.LineNumber);
+        } else if (fnSymGetSymFromAddr64(hProcess, s.AddrPC.Offset, &funcOffset, symbol)) {
+            brls::Logger::error("[{}]: {}!{} + {:#x}", n, mi.ImageName, symbol->Name, funcOffset);
+        } else {
+            brls::Logger::error("[{}]: {} + {:#x}", n, mi.ImageName, s.AddrPC.Offset);
+        }
+        n++;
+    }
+    fnSymCleanup(hProcess);
+
+    SYSTEMTIME lt;
+    CHAR tempPath[MAX_PATH];
+    ::GetLocalTime(&lt);
+    snprintf(tempPath, sizeof(tempPath), "crash-%04d%02d%02d-%02d%02d%02d.dmp", 
+        lt.wYear, lt.wMonth, lt.wDay, lt.wHour, lt.wMinute, lt.wSecond);
+    HANDLE hDump = ::CreateFileA(tempPath, GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr);
+
+    MINIDUMP_EXCEPTION_INFORMATION info;
+    info.ThreadId          = ::GetCurrentThreadId();
+    info.ExceptionPointers = pep;
+    info.ClientPointers    = TRUE;
+    fnMiniDumpWriteDump(hProcess, ::GetCurrentProcessId(), hDump, MiniDumpNormal, &info, nullptr, nullptr);
+    ::CloseHandle(hDump);
+
+    return EXCEPTION_CONTINUE_SEARCH;
+}
+
+void wiliwili::initCrashDump() { ::SetUnhandledExceptionFilter(createMiniDump); }
+
+#else
+
+void wiliwili::initCrashDump() {}
+
+#endif

--- a/wiliwili/source/view/mpv_core.cpp
+++ b/wiliwili/source/view/mpv_core.cpp
@@ -10,6 +10,7 @@
 
 #include "utils/config_helper.hpp"
 #include "utils/number_helper.hpp"
+#include "utils/crash_helper.hpp"
 #include "view/mpv_core.hpp"
 
 #ifdef MPV_BUNDLE_DLL
@@ -428,7 +429,9 @@ void MPVCore::init() {
         mpvTerminateDestroy(mpv);
         brls::fatal("failed to initialize mpv GL context");
     }
-
+#ifdef BOREALIS_USE_D3D11
+    wiliwili::initCrashDump();
+#endif
     brls::Logger::info("MPV Version: {}", mpvGetPropertyString(mpv, "mpv-version"));
     brls::Logger::info("FFMPEG Version: {}", mpvGetPropertyString(mpv, "ffmpeg-version"));
     command_async("set", "audio-client-name", APPVersion::getPackageName());


### PR DESCRIPTION
下载 [dbghelp.dll](https://www.dll-files.com/dbghelp.dll.html) 同 `wiliwili.pdb` 置于应用所在目录，如果遇到崩溃即可生成 `.dmp` 转储文件并打印堆栈日志