### PR TITLE
feat(player): add background playback support

### DIFF
--- a/resources/i18n/en-US/wiliwili.json
+++ b/resources/i18n/en-US/wiliwili.json
@@ -15,6 +15,7 @@
         "in_memory_cache": "Inmemory cache",
         "hwdec": "Hardware decode",
         "auto_play": "Auto-play on video detail page",
+        "background_play": "Background play",
         "exit_fullscreen": "Exit full screen at the end of playback",
         "play_strategy": "Play strategy",
         "auto_play_next_part": "Automatically playing next part",

--- a/resources/i18n/zh-Hans/wiliwili.json
+++ b/resources/i18n/zh-Hans/wiliwili.json
@@ -15,6 +15,7 @@
         "in_memory_cache": "解码缓存",
         "hwdec": "硬件解码",
         "auto_play": "视频详情页直接播放",
+        "background_play": "后台播放",
         "exit_fullscreen": "播放结束时自动退出全屏",
         "play_strategy": "播放方式",
         "auto_play_next_part": "自动播放分集",

--- a/resources/i18n/zh-Hant/wiliwili.json
+++ b/resources/i18n/zh-Hant/wiliwili.json
@@ -15,6 +15,7 @@
         "in_memory_cache": "解码緩存",
         "hwdec": "硬體解碼",
         "auto_play": "影片詳細頁直接播放",
+        "background_play": "後台播放",
         "exit_fullscreen": "播放結束時自動退出全屏",
         "play_strategy": "播放方式",
         "auto_play_next_part": "自動播放分集",

--- a/resources/xml/activity/setting_activity.xml
+++ b/resources/xml/activity/setting_activity.xml
@@ -90,6 +90,9 @@
                             <brls:BooleanCell
                                     id="setting/video/auto_play"/>
 
+                            <brls:BooleanCell
+                                    id="setting/video/background_play"/>
+
                         </brls:Box>
                     </brls:Box>
                 </brls:ScrollingFrame>

--- a/wiliwili/include/activity/setting_activity.hpp
+++ b/wiliwili/include/activity/setting_activity.hpp
@@ -56,6 +56,7 @@ private:
     BRLS_BIND(brls::BooleanCell, btnQuality, "setting/video/quality");
     BRLS_BIND(brls::BooleanCell, btnHWDEC, "setting/video/hwdec");
     BRLS_BIND(brls::BooleanCell, btnAutoPlay, "setting/video/auto_play");
+    BRLS_BIND(brls::BooleanCell, btnBackgroundPlay, "setting/video/background_play");
     BRLS_BIND(BiliSelectorCell, selectorInmemory, "setting/video/inmemory");
     BRLS_BIND(BiliSelectorCell, selectorFormat, "setting/video/format");
     BRLS_BIND(BiliSelectorCell, selectorCodec, "setting/video/codec");

--- a/wiliwili/include/utils/config_helper.hpp
+++ b/wiliwili/include/utils/config_helper.hpp
@@ -40,6 +40,7 @@ enum class SettingItem {
     SCROLL_SPEED,   // 列表滑动速度
     HISTORY_REPORT,
     PLAYER_AUTO_PLAY, // 进入详情页自动播放
+    PLAYER_BACKGROUND_PLAY, // 后台播放
     PLAYER_STRATEGY,
     PLAYER_BOTTOM_BAR,
     PLAYER_HIGHLIGHT_BAR,

--- a/wiliwili/include/view/mpv_core.hpp
+++ b/wiliwili/include/view/mpv_core.hpp
@@ -368,6 +368,9 @@ public:
     // 此变量为真时，加载结束后自动播放视频
     inline static bool AUTO_PLAY = true;
 
+    // 此变量为真时，在后台播放时不暂停播放
+    inline static bool BACKGROUND_PLAY = false;
+
     // 若值大于0 则当前时间大于 CLOSE_TIME 时，自动暂停播放
     inline static size_t CLOSE_TIME = 0;
 

--- a/wiliwili/source/activity/setting_activity.cpp
+++ b/wiliwili/source/activity/setting_activity.cpp
@@ -656,6 +656,13 @@ void SettingActivity::onContentAvailable() {
                           MPVCore::AUTO_PLAY = value;
                       });
 
+    /// Do not pause when playing in the background
+    btnBackgroundPlay->init("wiliwili/setting/app/playback/background_play"_i18n,
+                     conf.getBoolOption(SettingItem::PLAYER_BACKGROUND_PLAY), [](bool value) {
+                         ProgramConfig::instance().setSettingItem(SettingItem::PLAYER_BACKGROUND_PLAY, value);
+                         MPVCore::BACKGROUND_PLAY = value;
+                     });
+
     /// Decode quality
     btnQuality->init("wiliwili/setting/app/playback/low_quality"_i18n,
                      conf.getBoolOption(SettingItem::PLAYER_LOW_QUALITY), [](bool value) {

--- a/wiliwili/source/utils/config_helper.cpp
+++ b/wiliwili/source/utils/config_helper.cpp
@@ -118,6 +118,7 @@ std::unordered_map<SettingItem, ProgramOption> ProgramConfig::SETTING_MAP = {
 #endif
     {SettingItem::HISTORY_REPORT, {"history_report", {}, {}, 1}},
     {SettingItem::PLAYER_AUTO_PLAY, {"player_auto_play", {}, {}, 1}},
+    {SettingItem::PLAYER_BACKGROUND_PLAY, {"player_background_play", {}, {}, 0}},
     {SettingItem::PLAYER_BOTTOM_BAR, {"player_bottom_bar", {}, {}, 1}},
     {SettingItem::PLAYER_HIGHLIGHT_BAR, {"player_highlight_bar", {}, {}, 0}},
     {SettingItem::PLAYER_SKIP_OPENING_CREDITS, {"player_skip_opening_credits", {}, {}, 1}},
@@ -483,6 +484,9 @@ void ProgramConfig::load() {
 
     // 加载完成后自动播放
     MPVCore::AUTO_PLAY = getBoolOption(SettingItem::PLAYER_AUTO_PLAY);
+
+    // 在后台播放时不暂停
+    MPVCore::BACKGROUND_PLAY = getBoolOption(SettingItem::PLAYER_BACKGROUND_PLAY);
 
     // 初始化默认的倍速设定
     MPVCore::VIDEO_SPEED = getIntOption(SettingItem::PLAYER_DEFAULT_SPEED);

--- a/wiliwili/source/view/mpv_core.cpp
+++ b/wiliwili/source/view/mpv_core.cpp
@@ -463,9 +463,13 @@ void MPVCore::init() {
             // application is sleep, save the current state
             playing   = isPlaying();
             sleepTime = std::chrono::system_clock::now();
-            pause();
-            // do not automatically play video
-            AUTO_PLAY = false;
+            // determine behavior based on background play settings
+            BACKGROUND_PLAY = ProgramConfig::instance().getBoolOption(SettingItem::PLAYER_BACKGROUND_PLAY);
+            if (!BACKGROUND_PLAY) {
+                pause();
+                // do not automatically play video
+                AUTO_PLAY = false;
+            }
         }
     });
 


### PR DESCRIPTION
我想在 wiliwili 中添加一个后台播放功能（主要用于后台播放音乐），但由于我对项目代码和 C++ 不太熟悉，修改后构建的产物在运行时并未生效。
希望 wiliwili 的维护者能帮助我修正其中的逻辑问题。