### PR TITLE
New feature: Automatically publish to WinGet

### DIFF
--- a/.github/workflows/winget.yaml
+++ b/.github/workflows/winget.yaml
@@ -1,0 +1,15 @@
+name: Publish to WinGet
+
+on:
+  release:
+    types: released
+
+jobs:
+  publish:
+    runs-on: windows-latest
+    steps:
+      - uses: vedantmgoyal9/winget-releaser@main
+        with:
+          token: ${{ secrets.WINGET_TOKEN }}
+          identifier: xfangfang.Wiliwili
+          installers-regex: '^^wiliwili-Windows-[a-zA-Z0-9_]*.zip$'


### PR DESCRIPTION
## 概述

此 PR 向仓库添加了 `.github/workflows/winget.yaml` 配置文件，使用 [WinGet Releaser](https://github.com/marketplace/actions/winget-releaser) 构件、借助 _GitHub Workflows_ 功能、在 _GitHub Releases_ 正式版本发布时，在 [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs) 同步创建一个 Pull request 请求更新刚才发布的版本信息。

- 关联 https://github.com/xfangfang/wiliwili/discussions/92#discussioncomment-11306762

> [!TIP]
>
> 为了让此 Pull request 的改动在合并至主分支后的下一次发布 _GitHub Releases_ 时能够直接生效，本仓库所有者 @xfangfang 需要：
>
> 1. 在您的账号下，[Fork](https://github.com/microsoft/winget-pkgs/fork) `winget-pkgs` 这个仓库；
> 2. 申请一个 [**GitHub Personal Access Token (classic)**](https://github.com/settings/tokens/new) ，为其添加 `repo: public_repo` 权限，使其能否访问公开仓库。
> 3. 将申请的 PAT 添加到本仓库的 [Repository secrets](https://github.com/xfangfang/wiliwili/settings/secrets/actions/new) 中，将其命名为 `WINGET_TOKEN` 。

> [!WARNING]
>
> 此 YAML 配置文件已在本地（Windows 11 专业工作站 23H2）借助 [`nektos/act`](https://github.com/nektos/act) 和 [`Dragon1573/winget-releaser@feat/dryrun`](https://github.com/Dragon1573/winget-releaser/tree/feat/dryrun) 测试通过， [manifests](https://github.com/microsoft/winget-pkgs/tree/master/manifests/x/xfangfang/Wiliwili) 生成正确。
>
> 因本地环境与 **GitHub-hosted Runner** 存在差异，仍需待合并后观察其是否符合预期。