### PR TITLE
build: Optimize GitHub Pages Build Process

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -30,6 +30,9 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Pages
         uses: actions/configure-pages@v5
+      - name: Filter files
+        run: |
+          find . -type f -not \( -name "*.md" -o -name "*.svg" -o -name "*.png" -o -name "*.jpg" -o -name "*.jpeg" \) -delete
       - name: Build with Jekyll
         uses: actions/jekyll-build-pages@v1
         with:


### PR DESCRIPTION
- Added file filtering step to delete non-document and non-image files
- Keep .md, .svg, .png, .jpg, .jpeg files
- Improve build efficiency and reduce unnecessary file processing

Implement: #509 
Deployment: https://pj568.sbs/wiliwili/
Actions: https://github.com/PJ-568/wiliwili/actions/runs/14876343983/job/41784714467