### PR TITLE
qr_image.hpp: add a missing header

### DIFF
--- a/wiliwili/include/view/qr_image.hpp
+++ b/wiliwili/include/view/qr_image.hpp
@@ -8,6 +8,7 @@
 #include <qrcodegen.hpp>
 #include <pystring.h>
 #include <cstdlib>
+#include <sstream>
 #include <fmt/format.h>
 
 #include "view/svg_image.hpp"


### PR DESCRIPTION
Fixes this error:
```
In file included from /opt/local/var/macports/build/_opt_CatalinaPorts_multimedia_wiliwili/wiliwili/work/wiliwili-1.5.2/wiliwili/source/activity/player_base_activity.cpp:20:
/opt/local/var/macports/build/_opt_CatalinaPorts_multimedia_wiliwili/wiliwili/work/wiliwili-1.5.2/wiliwili/include/view/qr_image.hpp:68:28: error: implicit instantiation of undefined template 'std::__1::basic_ostringstream<char, std::__1::char_traits<char>, std::__1::allocator<char> >'
        std::ostringstream sb;
                           ^
/Library/Developer/CommandLineTools/usr/bin/../include/c++/v1/iosfwd:136:32: note: template is declared here
    class _LIBCPP_TEMPLATE_VIS basic_ostringstream;
                               ^
1 warning and 1 error generated.
make[2]: *** [CMakeFiles/wiliwili.dir/wiliwili/source/activity/player_base_activity.cpp.o] Error 1
```