### PR TITLE
metadata: Add vcs-browser URL

### DIFF
--- a/scripts/linux/cn.xfangfang.wiliwili.appdata.xml
+++ b/scripts/linux/cn.xfangfang.wiliwili.appdata.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<component type="desktop">
+<component type="desktop-application">
     <id>cn.xfangfang.wiliwili</id>
     <metadata_license>CC0-1.0</metadata_license>
     <project_license>GPL-3.0-only</project_license>
@@ -60,4 +60,5 @@
     </screenshots>
     <url type="homepage">https://github.com/xfangfang/wiliwili</url>
     <url type="bugtracker">https://github.com/xfangfang/wiliwili/issues</url>
+    <url type="vcs-browser">https://github.com/xfangfang/wiliwili</url>
 </component>


### PR DESCRIPTION
- Add vcs-browser URL
- Use desktop-application component type

See: https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines