### PR TITLE
feat: cdn prefs

### DIFF
--- a/resources/i18n/en-US/wiliwili.json
+++ b/resources/i18n/en-US/wiliwili.json
@@ -41,7 +41,10 @@
         "header": "Network",
         "tls": "TLS verify",
         "proxy": "Proxy",
-        "proxy_hint": "example: http://127.0.0.1:7890"
+        "proxy_hint": "example: http://127.0.0.1:7890",
+        "cdn": "CDN optimization",
+        "cdn_mirror": "Official CDN only",
+        "cdn_full": "Full (rewrite P2P links)"
       },
       "ui": {
         "header": "UI",

--- a/resources/i18n/it/wiliwili.json
+++ b/resources/i18n/it/wiliwili.json
@@ -41,7 +41,10 @@
         "header": "Rete",
         "tls": "Verifica TLS",
         "proxy": "Proxy",
-        "proxy_hint": "esempio: http://127.0.0.1:7890"
+        "proxy_hint": "esempio: http://127.0.0.1:7890",
+        "cdn": "Ottimizzazione CDN",
+        "cdn_mirror": "Solo CDN ufficiali",
+        "cdn_full": "Completa (riscrivi link P2P)"
       },
       "ui": {
         "header": "UI",

--- a/resources/i18n/ja-RYU/wiliwili.json
+++ b/resources/i18n/ja-RYU/wiliwili.json
@@ -41,7 +41,10 @@
         "header": "ネットワーク",
         "tls": "TLS検証",
         "proxy": "プロキシ",
-        "proxy_hint": "例：http://127.0.0.1:7890"
+        "proxy_hint": "例：http://127.0.0.1:7890",
+        "cdn": "CDN 最適化",
+        "cdn_mirror": "公式 CDN のみ",
+        "cdn_full": "フル（P2P リンクを書き換え）"
       },
       "ui": {
         "header": "UI",

--- a/resources/i18n/ja/wiliwili.json
+++ b/resources/i18n/ja/wiliwili.json
@@ -41,7 +41,10 @@
         "header": "ネットワーク",
         "tls": "TLS検証",
         "proxy": "プロキシ",
-        "proxy_hint": "例：http://127.0.0.1:7890"
+        "proxy_hint": "例：http://127.0.0.1:7890",
+        "cdn": "CDN 最適化",
+        "cdn_mirror": "公式 CDN のみ",
+        "cdn_full": "フル（P2P リンクを書き換え）"
       },
       "ui": {
         "header": "UI",

--- a/resources/i18n/ko/wiliwili.json
+++ b/resources/i18n/ko/wiliwili.json
@@ -41,7 +41,10 @@
         "header": "네트워크",
         "tls": "TLS 검증",
         "proxy": "프록시",
-        "proxy_hint": "예: http://127.0.0.1:7890"
+        "proxy_hint": "예: http://127.0.0.1:7890",
+        "cdn": "CDN 최적화",
+        "cdn_mirror": "공식 CDN만 사용",
+        "cdn_full": "전체 (P2P 링크 재작성)"
       },
       "ui": {
         "header": "사용자 인터페이스",

--- a/resources/i18n/zh-Hans/wiliwili.json
+++ b/resources/i18n/zh-Hans/wiliwili.json
@@ -41,7 +41,10 @@
         "header": "网络设置",
         "tls": "TLS 验证",
         "proxy": "网络代理",
-        "proxy_hint": "示例: http://127.0.0.1:7890"
+        "proxy_hint": "示例: http://127.0.0.1:7890",
+        "cdn": "CDN 优化",
+        "cdn_mirror": "仅使用官方 CDN",
+        "cdn_full": "完整策略（重写 P2P 链接）"
       },
       "ui": {
         "header": "界面设置",

--- a/resources/i18n/zh-Hant/wiliwili.json
+++ b/resources/i18n/zh-Hant/wiliwili.json
@@ -41,7 +41,10 @@
         "header": "網絡設定",
         "tls": "TLS 驗證",
         "proxy": "網絡代理",
-        "proxy_hint": "示例: http://127.0.0.1:7890"
+        "proxy_hint": "示例: http://127.0.0.1:7890",
+        "cdn": "CDN 優化",
+        "cdn_mirror": "僅使用官方 CDN",
+        "cdn_full": "完整策略（重寫 P2P 連結）"
       },
       "ui": {
         "header": "介面設定",

--- a/resources/xml/activity/setting_activity.xml
+++ b/resources/xml/activity/setting_activity.xml
@@ -280,6 +280,9 @@
                             <brls:InputCell
                                     id="setting/network/input"/>
 
+                            <SelectorCell
+                                    id="setting/network/cdn"/>
+
                         </brls:Box>
                     </brls:Box>
                 </brls:ScrollingFrame>

--- a/wiliwili/include/activity/setting_activity.hpp
+++ b/wiliwili/include/activity/setting_activity.hpp
@@ -44,6 +44,7 @@ private:
     BRLS_BIND(brls::BooleanCell, btnTls, "setting/network/tls");
     BRLS_BIND(brls::BooleanCell, btnProxy, "setting/network/proxy");
     BRLS_BIND(brls::InputCell, btnProxyInput, "setting/network/input");
+    BRLS_BIND(BiliSelectorCell, selectorCDN, "setting/network/cdn");
     BRLS_BIND(BiliSelectorCell, selectorLang, "setting/language");
     BRLS_BIND(BiliSelectorCell, selectorTheme, "setting/ui/theme");
     BRLS_BIND(BiliSelectorCell, selectorCustomTheme, "setting/custom/theme");

--- a/wiliwili/include/utils/cdn_helper.hpp
+++ b/wiliwili/include/utils/cdn_helper.hpp
@@ -1,0 +1,49 @@
+//
+// CDN optimization, ported from "Make Bilibili Great Than Ever Before"
+// https://github.com/SukkaW/Make-Bilibili-Great-Than-Ever-Before (src/utils/get-cdn-url.ts)
+//
+
+#pragma once
+
+#include <string>
+#include <vector>
+#include <unordered_set>
+
+namespace CDNHelper {
+
+enum class Mode {
+    OFF         = 0,
+    MIRROR_ONLY = 1,
+    FULL        = 2,
+};
+
+Mode getMode();
+
+enum class URLType {
+    MIRROR,
+    BCACHE,
+    P2P_UPGCXCODE,
+    MCDN_TF,
+    SZBDYD,
+    UNKNOWN,
+};
+
+URLType classify(const std::string& url);
+
+bool isP2PHost(const std::string& host);
+
+struct HostPool {
+    std::unordered_set<std::string> mirrorHosts;
+    std::unordered_set<std::string> bcacheHosts;
+
+    void collect(const std::string& url);
+};
+
+std::vector<std::string> optimize(const std::string& baseUrl, const std::vector<std::string>& backupUrls,
+                                  const HostPool& pool);
+
+std::string stripSmtcdns(const std::string& url);
+
+std::vector<std::string> rankLive(const std::vector<std::string>& urls);
+
+};  // namespace CDNHelper

--- a/wiliwili/include/utils/config_helper.hpp
+++ b/wiliwili/include/utils/config_helper.hpp
@@ -102,6 +102,7 @@ enum class SettingItem {
     HTTP_TIMEOUT,
     HTTP_CONNECTION_TIMEOUT,
     HTTP_DNS_CACHE_TIMEOUT,
+    CDN_OPTIMIZE, // CDN 优化: 0 关闭, 1 仅官方CDN, 2 完整策略
     UP_FILTER,
     LIVE_DANMAKU_FILTER_LEVEL,
     LIVE_SIDEBAR_DANMAKU_COUNT, // 直播间侧边栏弹幕数量上限

--- a/wiliwili/source/activity/live_player_activity.cpp
+++ b/wiliwili/source/activity/live_player_activity.cpp
@@ -15,6 +15,7 @@
 
 #include "utils/shader_helper.hpp"
 #include "utils/config_helper.hpp"
+#include "utils/cdn_helper.hpp"
 #include "utils/dialog_helper.hpp"
 
 #include "view/video_view.hpp"
@@ -370,13 +371,20 @@ void LiveActivity::onLiveData(const bilibili::LiveRoomPlayInfo &result)
             });
     }
 
-    // todo: 允许使用备用链接
+    std::vector<std::string> liveUrls;
+    liveUrls.reserve(liveUrl.url_info.size());
     for (const auto& i : liveUrl.url_info) {
-        auto url = i.host + liveUrl.base_url + i.extra;
+        liveUrls.emplace_back(i.host + liveUrl.base_url + i.extra);
+    }
+    liveUrls = CDNHelper::rankLive(liveUrls);
 
-        // 设置视频链接
-        brls::Logger::debug("Live stream url: {}", url);
-        this->video->setUrl(url);
+    if (!liveUrls.empty()) {
+        brls::Logger::debug("Live stream url: {}", liveUrls[0]);
+        this->video->setUrl(liveUrls[0]);
+        for (size_t i = 1; i < liveUrls.size(); i++) {
+            brls::Logger::debug("Live stream backup url: {}", liveUrls[i]);
+            this->video->setBackupUrl(liveUrls[i]);
+        }
         return;
     }
 

--- a/wiliwili/source/activity/player_base_activity.cpp
+++ b/wiliwili/source/activity/player_base_activity.cpp
@@ -13,6 +13,7 @@
 #include "fragment/player_coin.hpp"
 #include "fragment/player_single_comment.hpp"
 #include "utils/config_helper.hpp"
+#include "utils/cdn_helper.hpp"
 #include "utils/dialog_helper.hpp"
 #include "utils/number_helper.hpp"
 #include "presenter/comment_related.hpp"
@@ -593,6 +594,23 @@ void BasePlayerActivity::onVideoPlayUrl(const bilibili::VideoUrlResult& result) 
         }
     }
 
+    // 收集所有可用 CDN 节点，用于优化视频链接
+    CDNHelper::HostPool cdnPool;
+    {
+        auto collectMedia = [&cdnPool](const bilibili::DashMedia& m) {
+            cdnPool.collect(m.base_url);
+            for (const auto& u : m.backup_url) cdnPool.collect(u);
+        };
+        for (const auto& m : result.dash.video) collectMedia(m);
+        for (const auto& m : result.dash.audio) collectMedia(m);
+        for (const auto& m : result.dash.dolby_audio) collectMedia(m);
+        if (result.dash.has_flac) collectMedia(result.dash.flac_audio);
+        for (const auto& d : result.durl) {
+            cdnPool.collect(d.url);
+            for (const auto& u : d.backup_url) cdnPool.collect(u);
+        }
+    }
+
     if (!result.dash.video.empty()) {
         // dash
         brls::Logger::debug("Video type: dash");
@@ -679,17 +697,17 @@ void BasePlayerActivity::onVideoPlayUrl(const bilibili::VideoUrlResult& result) 
                 }
             }
             // 生成音频列表
-            audios.emplace_back(a.base_url);
-            audios.insert(audios.end(), a.backup_url.begin(), a.backup_url.end());
+            audios = CDNHelper::optimize(a.base_url, a.backup_url, cdnPool);
             brls::Logger::debug("Dash quality: {}; video: {}; audio: {}", videoUrlResult.quality, v.codecid, a.id);
         }
 
         // 给播放器设置链接
-        this->video->setUrl(v.base_url, start, end, audios);
+        std::vector<std::string> videoUrls = CDNHelper::optimize(v.base_url, v.backup_url, cdnPool);
+        this->video->setUrl(videoUrls[0], start, end, audios);
 
         // 设置备份视频链接
-        for (const auto& backup_url : v.backup_url) {
-            this->video->setBackupUrl(backup_url, start, end, audios);
+        for (size_t i = 1; i < videoUrls.size(); i++) {
+            this->video->setBackupUrl(videoUrls[i], start, end, audios);
         }
     } else {
         // flv
@@ -697,12 +715,17 @@ void BasePlayerActivity::onVideoPlayUrl(const bilibili::VideoUrlResult& result) 
         if (result.durl.empty()) {
             brls::Logger::error("No media");
         } else if (result.durl.size() == 1) {
-            this->video->setUrl(result.durl[0].url, start, end);
+            std::vector<std::string> urls = CDNHelper::optimize(result.durl[0].url, result.durl[0].backup_url, cdnPool);
+            this->video->setUrl(urls[0], start, end);
+            for (size_t i = 1; i < urls.size(); i++) {
+                this->video->setBackupUrl(urls[i], start, end);
+            }
         } else {
             std::vector<EDLUrl> urls;
             urls.reserve(result.durl.size());
             for (auto& i : result.durl) {
-                urls.emplace_back(i.url, i.length / 1000.0f);
+                auto optimized = CDNHelper::optimize(i.url, i.backup_url, cdnPool);
+                urls.emplace_back(optimized[0], i.length / 1000.0f);
             }
             this->video->setUrl(urls, start, end);
         }

--- a/wiliwili/source/activity/setting_activity.cpp
+++ b/wiliwili/source/activity/setting_activity.cpp
@@ -678,6 +678,17 @@ void SettingActivity::onContentAvailable() {
         },
         "wiliwili/setting/app/network/proxy_hint"_i18n, "wiliwili/setting/app/network/proxy_hint"_i18n, 64);
 
+    /// CDN optimize
+    auto cdnOption = conf.getOptionData(SettingItem::CDN_OPTIMIZE);
+    selectorCDN->init("wiliwili/setting/app/network/cdn"_i18n,
+                      {"hints/off"_i18n, "wiliwili/setting/app/network/cdn_mirror"_i18n,
+                       "wiliwili/setting/app/network/cdn_full"_i18n},
+                      conf.getIntOptionIndex(SettingItem::CDN_OPTIMIZE), [cdnOption](int data) {
+                          ProgramConfig::instance().setSettingItem(SettingItem::CDN_OPTIMIZE,
+                                                                   cdnOption.rawOptionList[data]);
+                          return true;
+                      });
+
 /// Hardware decode
 #if defined(PS4) || defined(__PSV__) && defined(BOREALIS_USE_OPENGL)
     btnHWDEC->setVisibility(brls::Visibility::GONE);

--- a/wiliwili/source/utils/cdn_helper.cpp
+++ b/wiliwili/source/utils/cdn_helper.cpp
@@ -1,0 +1,332 @@
+//
+// CDN optimization, ported from
+// https://github.com/SukkaW/Make-Bilibili-Great-Than-Ever-Before
+//   (src/utils/get-cdn-url.ts)
+//
+
+#include <random>
+#include <cctype>
+#include <cstring>
+#include <algorithm>
+
+#include <borealis/core/logger.hpp>
+
+#include "utils/cdn_helper.hpp"
+#include "utils/config_helper.hpp"
+#include "utils/string_helper.hpp"
+
+namespace CDNHelper {
+
+inline const std::string PROXY_TF          = "proxy-tf-all-ws.bilivideo.com";
+inline const std::string FALLBACK_CDN_HOST = "upos-sz-mirrorali.bilivideo.com";
+
+struct ParsedUrl {
+    std::string scheme, host, port, path, query;
+    bool valid = false;
+};
+
+static ParsedUrl parseUrl(const std::string& raw) {
+    ParsedUrl u;
+    std::string url = raw;
+    if (url.rfind("//", 0) == 0) {
+        u.scheme = "https";
+        url      = "https:" + url;
+    }
+    size_t schemeEnd = url.find("://");
+    if (schemeEnd == std::string::npos) return u;
+    u.scheme = url.substr(0, schemeEnd);
+
+    size_t hostStart = schemeEnd + 3;
+    size_t hostEnd   = url.find_first_of("/?#", hostStart);
+    std::string authority =
+        hostEnd == std::string::npos ? url.substr(hostStart) : url.substr(hostStart, hostEnd - hostStart);
+    if (authority.empty()) return u;
+
+    size_t colon = authority.rfind(':');
+    if (colon != std::string::npos) {
+        u.host = authority.substr(0, colon);
+        u.port = authority.substr(colon + 1);
+    } else {
+        u.host = authority;
+    }
+    if (u.host.empty()) return u;
+
+    std::string rest = hostEnd == std::string::npos ? "" : url.substr(hostEnd);
+    size_t q         = rest.find('?');
+    if (q == std::string::npos) {
+        u.path = rest.empty() ? "/" : rest;
+    } else {
+        u.path  = q == 0 ? "/" : rest.substr(0, q);
+        u.query = rest.substr(q + 1);
+    }
+    u.valid = true;
+    return u;
+}
+
+static std::string buildUrl(const ParsedUrl& u) {
+    std::string out = u.scheme + "://" + u.host;
+    if (!u.port.empty() && u.port != "443" && u.port != "80") out += ":" + u.port;
+    out += u.path;
+    if (!u.query.empty()) out += "?" + u.query;
+    return out;
+}
+
+static bool startsWith(const std::string& s, const std::string& prefix) {
+    return s.size() >= prefix.size() && s.compare(0, prefix.size(), prefix) == 0;
+}
+
+static bool endsWith(const std::string& s, const std::string& suffix) {
+    return s.size() >= suffix.size() && s.compare(s.size() - suffix.size(), suffix.size(), suffix) == 0;
+}
+
+static std::string getQueryParam(const std::string& query, const std::string& key) {
+    size_t pos = 0;
+    while (pos <= query.size()) {
+        size_t amp     = query.find('&', pos);
+        std::string kv = query.substr(pos, amp == std::string::npos ? std::string::npos : amp - pos);
+        size_t eq      = kv.find('=');
+        if (eq != std::string::npos && kv.substr(0, eq) == key) return kv.substr(eq + 1);
+        if (amp == std::string::npos) break;
+        pos = amp + 1;
+    }
+    return "";
+}
+
+bool isP2PHost(const std::string& host) {
+    static const char* keywords[] = {"302ppio",
+                                     "302kodo",
+                                     ".mcdn.bilivideo",
+                                     "szbdyd.com",
+                                     ".nexusedgeio.com",
+                                     ".ahdohpiechei.com",
+                                     "upos-sz-mirror14b.bilivideo.com"};
+    for (const char* kw : keywords) {
+        if (host.find(kw) != std::string::npos) return true;
+    }
+    std::string firstLabel = host.substr(0, host.find('.'));
+    return firstLabel.find("302") != std::string::npos;
+}
+
+static bool isMirrorHost(const std::string& host) {
+    static const char* suffixes[] = {".bilivideo.com", ".bilivideo.net", ".akamaized.com", ".akamaized.net"};
+    for (const char* suffix : suffixes) {
+        if (!endsWith(host, suffix)) continue;
+        std::string sub = host.substr(0, host.size() - strlen(suffix));
+        if (startsWith(sub, "upos-tf-") || startsWith(sub, "proxy-tf-")) return true;
+        if (startsWith(sub, "upos-")) {
+            std::string rest = sub.substr(5);
+            size_t dash      = rest.find('-');
+            if (dash > 0 && dash != std::string::npos && dash + 1 < rest.size() &&
+                !startsWith(rest.substr(dash + 1), "302"))
+                return true;
+        }
+    }
+    return false;
+}
+
+static bool isIPv4Host(const std::string& host) {
+    int dots = 0;
+    for (char c : host) {
+        if (c == '.')
+            dots++;
+        else if (!isdigit((unsigned char)c))
+            return false;
+    }
+    return dots == 3;
+}
+
+static bool isMcdnTfUrl(const ParsedUrl& u) {
+    bool mcdnHost = isIPv4Host(u.host) || endsWith(u.host, ".mcdn.bilivideo.com") ||
+                    endsWith(u.host, ".mcdn.bilivideo.cn") || endsWith(u.host, ".mcdn.bilivideo.net");
+    if (!mcdnHost) return false;
+    if (!startsWith(u.path, "/v") || u.path.size() < 3 || !isdigit((unsigned char)u.path[2])) return false;
+    size_t next = u.path.find('/', 1);
+    return next != std::string::npos && u.path.compare(next, 9, "/resource") == 0;
+}
+
+URLType classify(const std::string& url) {
+    ParsedUrl u = parseUrl(url);
+    if (!u.valid) return URLType::UNKNOWN;
+
+    if (url.find("/upgcxcode/") != std::string::npos) {
+        if (isMirrorHost(u.host)) {
+            if (getQueryParam(u.query, "os") == "mcdn" || isP2PHost(u.host)) return URLType::P2P_UPGCXCODE;
+            return URLType::MIRROR;
+        }
+        if (isP2PHost(u.host)) return URLType::P2P_UPGCXCODE;
+        return URLType::BCACHE;
+    }
+
+    if (isMcdnTfUrl(u)) return URLType::MCDN_TF;
+
+    if (url.find("szbdyd.com") != std::string::npos) return URLType::SZBDYD;
+
+    return URLType::UNKNOWN;
+}
+
+void HostPool::collect(const std::string& url) {
+    URLType type = classify(url);
+    if (type == URLType::MIRROR) {
+        mirrorHosts.insert(parseUrl(url).host);
+    } else if (type == URLType::BCACHE) {
+        bcacheHosts.insert(parseUrl(url).host);
+    }
+}
+
+static std::mt19937& rng() {
+    static std::mt19937 gen{std::random_device{}()};
+    return gen;
+}
+
+static std::string pickOne(const std::unordered_set<std::string>& hosts) {
+    if (hosts.empty()) return "";
+    auto it = hosts.begin();
+    std::advance(it, std::uniform_int_distribution<size_t>(0, hosts.size() - 1)(rng()));
+    return *it;
+}
+
+static std::string forceHttps(const std::string& url) {
+    ParsedUrl u = parseUrl(url);
+    if (!u.valid) return url;
+    u.scheme = "https";
+    u.port.clear();
+    return buildUrl(u);
+}
+
+static std::string replaceUpgcxcodeHost(const std::string& url, const HostPool& pool) {
+    ParsedUrl u = parseUrl(url);
+    if (!u.valid) return url;
+    u.scheme = "https";
+    u.port.clear();
+
+    std::string host = pickOne(pool.mirrorHosts);
+    if (host.empty()) host = pickOne(pool.bcacheHosts);
+    if (host.empty()) host = FALLBACK_CDN_HOST;
+    u.host = host;
+    return buildUrl(u);
+}
+
+Mode getMode() {
+    int value = ProgramConfig::instance().getIntOption(SettingItem::CDN_OPTIMIZE);
+    // 配置文件被手动改出范围时按关闭处理
+    if (value < static_cast<int>(Mode::OFF) || value > static_cast<int>(Mode::FULL)) return Mode::OFF;
+    return static_cast<Mode>(value);
+}
+
+std::vector<std::string> optimize(const std::string& baseUrl, const std::vector<std::string>& backupUrls,
+                                  const HostPool& pool) {
+    std::vector<std::string> input;
+    input.reserve(backupUrls.size() + 1);
+    input.emplace_back(baseUrl);
+    input.insert(input.end(), backupUrls.begin(), backupUrls.end());
+
+    Mode mode = getMode();
+    if (mode == Mode::OFF || baseUrl.empty()) return input;
+
+    std::vector<std::string> mirrorUrls, bcacheUrls, p2pUrls, szbdydUrls, tfUrls, unknownUrls;
+    for (const auto& url : input) {
+        switch (classify(url)) {
+            case URLType::MIRROR:
+                mirrorUrls.emplace_back(forceHttps(url));
+                break;
+            case URLType::BCACHE:
+                bcacheUrls.emplace_back(url);
+                break;
+            case URLType::P2P_UPGCXCODE:
+                p2pUrls.emplace_back(url);
+                break;
+            case URLType::SZBDYD:
+                szbdydUrls.emplace_back(url);
+                break;
+            case URLType::MCDN_TF:
+                tfUrls.emplace_back(url);
+                break;
+            default:
+                unknownUrls.emplace_back(url);
+                break;
+        }
+    }
+
+    // 同一优先级内随机排序以分散负载，不同优先级之间保持顺序
+    std::shuffle(mirrorUrls.begin(), mirrorUrls.end(), rng());
+    std::shuffle(bcacheUrls.begin(), bcacheUrls.end(), rng());
+    std::shuffle(p2pUrls.begin(), p2pUrls.end(), rng());
+    std::shuffle(szbdydUrls.begin(), szbdydUrls.end(), rng());
+    std::shuffle(tfUrls.begin(), tfUrls.end(), rng());
+
+    std::vector<std::string> result;
+    if (mode == Mode::MIRROR_ONLY) {
+        result.insert(result.end(), mirrorUrls.begin(), mirrorUrls.end());
+        result.insert(result.end(), bcacheUrls.begin(), bcacheUrls.end());
+        // UNKNOWN 未被判定为 P2P，保留作为兜底
+        result.insert(result.end(), unknownUrls.begin(), unknownUrls.end());
+    } else {
+        // 各优先级依次拼接，低优先级链接改写后保留为播放失败时的备选
+        result.insert(result.end(), mirrorUrls.begin(), mirrorUrls.end());
+        result.insert(result.end(), bcacheUrls.begin(), bcacheUrls.end());
+        for (const auto& url : p2pUrls) result.emplace_back(replaceUpgcxcodeHost(url, pool));
+        for (const auto& url : szbdydUrls) {
+            ParsedUrl u      = parseUrl(url);
+            std::string usrc = u.valid ? getQueryParam(u.query, "xy_usource") : "";
+            if (!usrc.empty()) {
+                u.scheme = "https";
+                u.port.clear();
+                u.host = usrc;
+                result.emplace_back(buildUrl(u));
+            } else {
+                result.emplace_back(replaceUpgcxcodeHost(url, pool));
+            }
+        }
+        for (const auto& url : tfUrls) {
+            result.emplace_back("https://" + PROXY_TF + "/?url=" + wiliwili::urlEncode(url));
+        }
+        result.insert(result.end(), unknownUrls.begin(), unknownUrls.end());
+    }
+
+    if (result.empty()) {
+        brls::Logger::warning("CDNHelper: no usable CDN url, fallback to original list");
+        return input;
+    }
+
+    brls::Logger::debug("CDNHelper: {} -> {}", baseUrl, result[0]);
+    return result;
+}
+
+std::string stripSmtcdns(const std::string& url) {
+    size_t scheme = url.find("://");
+    if (scheme == std::string::npos) return url;
+    size_t hostStart = scheme + 3;
+    size_t hostEnd   = url.find('/', hostStart);
+    if (hostEnd == std::string::npos) return url;
+    // 外层 host 必须以 .smtcdns.net 结尾
+    if (!endsWith(url.substr(hostStart, hostEnd - hostStart), ".smtcdns.net")) return url;
+    // 内层 host 必须紧随其后且以 .bilivideo.com 结尾
+    std::string rest = url.substr(hostEnd + 1);
+    size_t innerEnd  = rest.find_first_of("/?#");
+    if (innerEnd == std::string::npos) return url;
+    if (!endsWith(rest.substr(0, innerEnd), ".bilivideo.com")) return url;
+    return url.substr(0, hostStart) + rest;
+}
+
+std::vector<std::string> rankLive(const std::vector<std::string>& urls) {
+    Mode mode = getMode();
+    if (mode == Mode::OFF) return urls;
+
+    std::vector<std::string> clean, rest;
+    for (const auto& raw : urls) {
+        std::string url = stripSmtcdns(raw);
+        ParsedUrl u     = parseUrl(url);
+        bool ok         = u.valid && !isP2PHost(u.host) &&
+                          (endsWith(u.host, ".bilivideo.com") || endsWith(u.host, ".bilivideo.net") ||
+                           endsWith(u.host, ".akamaized.net"));
+        (ok ? clean : rest).emplace_back(url);
+    }
+
+    if (mode == Mode::MIRROR_ONLY) {
+        return clean.empty() ? urls : clean;
+    }
+    clean.insert(clean.end(), rest.begin(), rest.end());
+    return clean.empty() ? urls : clean;
+}
+
+};  // namespace CDNHelper

--- a/wiliwili/source/utils/config_helper.cpp
+++ b/wiliwili/source/utils/config_helper.cpp
@@ -299,6 +299,7 @@ std::unordered_map<SettingItem, ProgramOption> ProgramConfig::SETTING_MAP = {
     {SettingItem::HTTP_TIMEOUT, {"http_timeout", {}, {}, 0}},
     {SettingItem::HTTP_CONNECTION_TIMEOUT, {"http_connection_timeout", {}, {}, 0}},
     {SettingItem::HTTP_DNS_CACHE_TIMEOUT, {"http_dns_cache_timeout", {}, {}, 0}},
+    {SettingItem::CDN_OPTIMIZE, {"cdn_optimize", {"off", "mirror_only", "full"}, {0, 1, 2}, 0}},
     {SettingItem::LIVE_SIDEBAR_DANMAKU_COUNT,
      {"live_sidebar_danmaku_count", {"0", "10", "25", "50", "100"}, {0, 10, 25, 50, 100}, 0}},
 


### PR DESCRIPTION
# 视频 / 直播播放的 CDN 优化

将 [Make Bilibili Great Than Ever Before](https://github.com/SukkaW/Make-Bilibili-Great-Than-Ever-Before) (`src/utils/get-cdn-url.ts`、`src/modules/enhance-live.ts`) 中的 CDN 优化逻辑移植到 wiliwili。

B 站 playurl 响应中混杂着官方 CDN 镜像与 P2P/PCDN 节点。P2P 节点速度慢、限速, 还会占用用户上行带宽。

此前 wiliwili 直接原样使用服务端返回的 `base_url`:

- `player_base_activity.cpp:onVideoPlayUrl` 直接把 `v.base_url` 传给 `setUrl()`,`backup_url` 仅作为 mpv 播放列表回退,不检查主机。
- FLV/`durl` 路径完全忽略 `durl[].backup_url`。
- `live_player_activity.cpp` 只用第一个 `url_info`,留有 todo: 允许使用备用链接。

## 移植内容

### URL 分类(`CDNHelper::classify`)

| 类型 | 匹配规则 |
|---|---|
| `MIRROR` | `upos-<region>-<node>` / `upos-tf-*` / `proxy-tf-*`,域名为 `bilivideo.{com,net}` 或 `akamaized.{com,net}`,路径含 `/upgcxcode/` |
| `BCACHE` | 其他 `/upgcxcode/` host (B 站自建 PoP,如 `cn-sccd-cu-01-01.bilivideo.com`) |
| `P2P_UPGCXCODE` | P2P 主机上的 `/upgcxcode/` URL, 签名在 path+query 中仍可复用,只有主机不可用 |
| `MCDN_TF` | 裸 IPv4 或 `*.mcdn.bilivideo.{com,cn,net}`,路径为 `/v<N>/resource` |
| `SZBDYD` | 已废弃的 `szbdyd.com` CDN |

P2P 判定利用了脚本里的规则: 关键字列表(`302ppio`、`302kodo`、`.mcdn.bilivideo`、`szbdyd.com`、`.nexusedgeio.com`、`.ahdohpiechei.com`, 以及证书签给 `*.bilivideo.cn` 的黑名单条目 `upos-sz-mirror14b.bilivideo.com`)、"首段子域名含 `302`"启发式、以及对带 `os=mcdn` 参数的官方镜像的降级。

### 排序阶梯 (`CDNHelper::optimize`)

1. `MIRROR`
2. `BCACHE`
3. `P2P_UPGCXCODE`, 主机替换为从响应中收集到的官方主机(兜底 `upos-sz-mirrorali.bilivideo.com`); 所有 `/upgcxcode/` 主机可互换,因为签名在 path+query 中
4. `SZBDYD`, 改写为其 `xy_usource` 主机,否则做主机替换
5. `MCDN_TF`, 包进 B 站官方代理: `https://proxy-tf-all-ws.bilivideo.com/?url=<encoded>`

所有改写后的 URL 强制 `https` / 443 端口。同档内随机排序以分散负载 (即原脚本中的 `pickOne`); 各档按优先级拼接, 低档保留为回退而非丢弃(用户脚本只替换单个 URL、依赖网页播放器重试,这里一次性构建完整的 mpv 回退列表)。无法识别的 URL 在两种开启模式下均保留在列表末尾。首个条目为主 URL, 其余为 mpv 播放列表回退。

主机池从**整个** playurl 响应(全部视频、音频、杜比、FLAC 及 `durl` 条目)收集,因此即使某条流的 URL 全是 P2P,也能借用响应中其他位置出现的干净主机。

### 直播

来自 `enhance-live.ts`:剥离 `*.smtcdns.net/<real-host>/` 反向代理包装,再将非 P2P 的 `bilivideo`/`akamaized` 主机排在前面。两步均在 `rankLive()` 内完成,设置为 `off` 时完全跳过。画质强制未移植, wiliwili 本就显式选择 `qn`。

## 设置项

新增 `SettingItem::CDN_OPTIMIZE`, 位于 **设置 → 网络 → CDN 优化**:

| 取值 | 行为 |
|---|---|
| `off` (默认) | URL 原样使用,不改写不重排 |
| `mirror_only` | 只保留官方 mirror/bcache URL (及无法识别的), P2P 链接直接丢弃 |
| `full` | 完整阶梯, 包括对 P2P 链接的主机替换与代理包装 |

手改配置文件出现越界值时按 `off` 处理。

若某档过滤后没有可播放的 URL,则原样返回原始列表并记录警告,过滤再激进也不会导致无法播放。