### PR TITLE
fix: set Wayland app_id / X11 WM_CLASS to fix missing taskbar icon

### DIFF
--- a/wiliwili/source/main.cpp
+++ b/wiliwili/source/main.cpp
@@ -45,6 +45,10 @@ int main(int argc, char* argv[]) {
     // Return directly to the desktop when closing the application (only for NX)
     brls::Application::getPlatform()->exitToHomeMode(true);
 
+    // Set the application ID so desktop environments can match the window to its
+    // .desktop entry (fixes missing taskbar icon on Wayland/X11)
+    brls::Application::setAppId("cn.xfangfang.wiliwili");
+
     brls::Application::createWindow("wiliwili");
     brls::Logger::info("createWindow done");
 


### PR DESCRIPTION
## 问题 / Problem

KDE Plasma 等桌面环境在 Wayland 下通过窗口的 **app_id**（X11 下为 WM_CLASS）将窗口关联到 `.desktop` 条目。当前 wiliwili 的窗口 app_id 为空（KWin 实测 `resourceClass=""`），无法匹配到 `cn.xfangfang.wiliwili.desktop`，导致**图标任务栏不显示图标**。

## 修复 / Fix

在 `createWindow()` 前调用 `brls::Application::setAppId("cn.xfangfang.wiliwili")`，窗口将以 `cn.xfangfang.wiliwili` 作为 Wayland app_id / X11 WM_CLASS，任务栏即可正确匹配 desktop 条目并显示图标。

依赖 borealis 的 API 支持：xfangfang/borealis#129（`Application::setAppId`）