### PR TITLE
修复 macOS 26 下的窗口阴影问题

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,6 +185,12 @@ endif ()
 
 # source cpp
 file(GLOB_RECURSE MAIN_SRC wiliwili/source/*.cpp)
+if (APPLE AND PLATFORM_DESKTOP)
+    enable_language(OBJC OBJCXX)
+    list(APPEND MAIN_SRC wiliwili/source/utils/macos_helper.mm)
+    find_library(APPKIT_FRAMEWORK AppKit)
+    list(APPEND APP_PLATFORM_LIB ${APPKIT_FRAMEWORK})
+endif ()
 if (WIN32)
     configure_file("${CMAKE_SOURCE_DIR}/wiliwili/app_win32.rc.in" "${CMAKE_BINARY_DIR}/app_win32.rc")
     list(APPEND MAIN_SRC ${CMAKE_BINARY_DIR}/app_win32.rc)

--- a/wiliwili/include/utils/macos_helper.hpp
+++ b/wiliwili/include/utils/macos_helper.hpp
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace MacOSHelper {
+
+void disableWindowShadow();
+
+}

--- a/wiliwili/source/main.cpp
+++ b/wiliwili/source/main.cpp
@@ -15,6 +15,10 @@
 #include "utils/activity_helper.hpp"
 #include "view/mpv_core.hpp"
 
+#if defined(__APPLE__) && !defined(IOS)
+#include "utils/macos_helper.hpp"
+#endif
+
 #ifdef IOS
 #include <SDL2/SDL_main.h>
 #endif
@@ -46,6 +50,9 @@ int main(int argc, char* argv[]) {
     brls::Application::getPlatform()->exitToHomeMode(true);
 
     brls::Application::createWindow("wiliwili");
+#if defined(__APPLE__) && !defined(IOS)
+    MacOSHelper::disableWindowShadow();
+#endif
     brls::Logger::info("createWindow done");
 
     // Register custom view\theme\style

--- a/wiliwili/source/utils/macos_helper.mm
+++ b/wiliwili/source/utils/macos_helper.mm
@@ -1,0 +1,15 @@
+#import <AppKit/AppKit.h>
+
+#include "utils/macos_helper.hpp"
+
+namespace MacOSHelper {
+
+void disableWindowShadow() {
+    if (@available(macOS 26.0, *)) {
+        for (NSWindow* window in NSApplication.sharedApplication.windows) {
+            window.hasShadow = NO;
+        }
+    }
+}
+
+}


### PR DESCRIPTION
## 修改内容

- 新增 macOS 平台辅助方法，在窗口创建完成后通过 AppKit 将 `NSWindow.hasShadow` 设置为 `NO`。
- 使用 `@available(macOS 26.0, *)` 限制生效范围，仅在 macOS 26 及以后关闭窗口阴影。
- macOS 桌面构建中启用 Objective-C 与 Objective-C++，并链接 AppKit。
- 调用入口使用 Apple 桌面平台条件编译，不影响 iOS、Windows、Linux 和主机平台。

## 修改原因

macOS 26 会为应用原生窗口绘制系统窗口阴影，而 wiliwili 的界面由自身渲染，该阴影会造成不符合预期的窗口外观。通过在窗口创建后关闭 AppKit 窗口阴影，可以恢复预期显示效果。

这里没有修改 GLFW 或 SDL 的内部实现，而是统一操作应用当前的 `NSWindow`，因此两种桌面窗口后端都可以复用；同时保留版本判断，避免改变旧版 macOS 上已有的窗口表现。

## 验证

- 系统：macOS 26.5
- 架构：Apple Silicon arm64
- 配置：`-DPLATFORM_DESKTOP=ON -DMAC_AppleSilicon=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_ARCHITECTURES=arm64`
- `wiliwili` Release 目标编译、链接成功。
- `wiliwili.app` 打包成功，Mach-O 架构确认是 arm64。
- AppKit 辅助代码通过最低部署版本 macOS 10.11 的严格语法与链接检查。
- 已实际运行验证，macOS 26 下窗口阴影成功关闭。